### PR TITLE
chore(project): update engines.node and circle CI to Node.js 8.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:8.11
+      - image: circleci/node:8
     working_directory: ~/repo
 
     steps:

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "repository": "git@github.com:IBM/carbon-elements.git",
   "license": "Apache-2.0",
+  "engines": {
+    "node": "8.x"
+  },
   "workspaces": {
     "packages": [
       "packages/*"


### PR DESCRIPTION
Enforce Node.js `8.x` requirement through `engines.node` in the root `package.json`. Also updates CircleCI image.

#### Changelog

**New**

**Changed**

- `.circleci/config.yml` now uses `circleci/node:8`
- `package.json` now species `8.x` for `engines.node`

**Removed**
