### PR TITLE
fix(icons-angular): add icon-helpers as a direct dependency

### DIFF
--- a/packages/icons-angular/package.json
+++ b/packages/icons-angular/package.json
@@ -28,6 +28,9 @@
     "@angular/compiler": "^6.0.0",
     "@angular/core": "^6.0.0"
   },
+  "dependencies": {
+    "@carbon/icon-helpers": "0.0.1-alpha.17"
+  },
   "devDependencies": {
     "@angular/compiler": "6.1.10",
     "@angular/compiler-cli": "6.1.10",


### PR DESCRIPTION
This way consumers don't need to add it as a dependency! (oops 😅)