### PR TITLE
IDL Glyphs

### DIFF
--- a/packages/icons/src/svg/caret--down.svg
+++ b/packages/icons/src/svg/caret--down.svg
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="10px" height="5px" viewBox="0 0 10 5" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 50.2 (55047) - http://www.bohemiancoding.com/sketch -->
-    <title>caret--down</title>
-    <desc>Created with Sketch.</desc>
-    <defs></defs>
-    <g id="caret--down" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <polygon id="caret" fill="#000000" points="0 0 5 4.99774791 10 0"></polygon>
-    </g>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="icon" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="8px" height="4px" viewBox="0 0 8 4" style="enable-background:new 0 0 8 4;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<polygon points="8,0 4,4 0,0 "/>
+<rect id="_Transparent_Rectangle_" class="st0" width="8" height="4"/>
 </svg>

--- a/packages/icons/src/svg/caret--left.svg
+++ b/packages/icons/src/svg/caret--left.svg
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="5px" height="10px" viewBox="0 0 5 10" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 50.2 (55047) - http://www.bohemiancoding.com/sketch -->
-    <title>caret--left</title>
-    <desc>Created with Sketch.</desc>
-    <defs></defs>
-    <g id="caret--left" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <polygon id="caret" fill="#000000" transform="translate(2.498874, 5.000000) scale(1, -1) rotate(90.000000) translate(-2.498874, -5.000000) " points="-2.50112604 2.50112604 2.49887396 7.49887396 7.49887396 2.50112604"></polygon>
-    </g>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="icon" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="5px" height="8px" viewBox="0 0 5 8" style="enable-background:new 0 0 5 8;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<polygon points="5,8 0,4 5,0 "/>
+<rect class="st0" width="5" height="8"/>
 </svg>

--- a/packages/icons/src/svg/caret--right.svg
+++ b/packages/icons/src/svg/caret--right.svg
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="5px" height="10px" viewBox="0 0 5 10" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 50.2 (55047) - http://www.bohemiancoding.com/sketch -->
-    <title>caret--right</title>
-    <desc>Created with Sketch.</desc>
-    <defs></defs>
-    <g id="caret--right" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <polygon id="caret" fill="#000000" transform="translate(2.498874, 5.000000) scale(-1, -1) rotate(90.000000) translate(-2.498874, -5.000000) " points="-2.50112604 2.50112604 2.49887396 7.49887396 7.49887396 2.50112604"></polygon>
-    </g>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="icon" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="5px" height="8px" viewBox="0 0 5 8" style="enable-background:new 0 0 5 8;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<polygon points="0,0 5,4 0,8 "/>
+<rect class="st0" width="5" height="8"/>
 </svg>

--- a/packages/icons/src/svg/caret--up.svg
+++ b/packages/icons/src/svg/caret--up.svg
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="10px" height="5px" viewBox="0 0 10 5" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 50.2 (55047) - http://www.bohemiancoding.com/sketch -->
-    <title>caret--up</title>
-    <desc>Created with Sketch.</desc>
-    <defs></defs>
-    <g id="caret--up" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <polygon id="caret" fill="#000000" transform="translate(5.000000, 2.501126) scale(1, -1) translate(-5.000000, -2.501126) " points="-4.4408921e-16 0.00225208898 5 5 10 0.00225208898"></polygon>
-    </g>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="icon" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="8px" height="4px" viewBox="0 0 8 4" style="enable-background:new 0 0 8 4;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<polygon points="0,4 4,0 8,4 "/>
+<rect id="_Transparent_Rectangle_" class="st0" width="8" height="4"/>
 </svg>

--- a/packages/icons/src/svg/chevron--down.svg
+++ b/packages/icons/src/svg/chevron--down.svg
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="12px" height="7px" viewBox="0 0 12 7" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 50.2 (55047) - http://www.bohemiancoding.com/sketch -->
-    <title>chevron--down</title>
-    <desc>Created with Sketch.</desc>
-    <defs></defs>
-    <g id="chevron--down" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <polygon id="chevron" fill="#000000" fill-rule="nonzero" transform="translate(5.998096, 3.500000) rotate(180.000000) translate(-5.998096, -3.500000) " points="5.99408113 1.44972267 0.726461685 6.99971556 -5.79924997e-13 6.31479463 5.99350948 -2.74780199e-14 11.996192 6.31451019 11.2702706 7"></polygon>
-    </g>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="icon" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="10px" height="6px" viewBox="0 0 10 6" style="enable-background:new 0 0 10 6;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<polygon points="5,6 0,1 0.7,0.3 5,4.6 9.3,0.3 10,1 "/>
+<rect id="_x3C_Transparent_Rectangle_x3E_" class="st0" width="10" height="6"/>
 </svg>

--- a/packages/icons/src/svg/chevron--left.svg
+++ b/packages/icons/src/svg/chevron--left.svg
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="7px" height="12px" viewBox="0 0 7 12" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 50.2 (55047) - http://www.bohemiancoding.com/sketch -->
-    <title>chevron--left</title>
-    <desc>Created with Sketch.</desc>
-    <defs></defs>
-    <g id="chevron--left" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <polygon id="chevron" fill="#000000" fill-rule="nonzero" transform="translate(3.500000, 5.998096) rotate(-90.000000) translate(-3.500000, -5.998096) " points="3.49598515 3.94781865 -1.77163429 9.49781153 -2.49809598 8.81289061 3.49541351 2.49809598 9.49809598 8.81260617 8.77217466 9.49809598"></polygon>
-    </g>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="icon" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="6px" height="10px" viewBox="0 0 6 10" style="enable-background:new 0 0 6 10;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<polygon points="0,5 5,0 5.7,0.7 1.4,5 5.7,9.3 5,10 "/>
+<rect id="_x3C_Transparent_Rectangle_x3E_" class="st0" width="6" height="10"/>
 </svg>

--- a/packages/icons/src/svg/chevron--right.svg
+++ b/packages/icons/src/svg/chevron--right.svg
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="7px" height="12px" viewBox="0 0 7 12" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 50.2 (55047) - http://www.bohemiancoding.com/sketch -->
-    <title>chevron--right</title>
-    <desc>Created with Sketch.</desc>
-    <defs></defs>
-    <g id="chevron--right" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <polygon id="chevron" fill="#000000" fill-rule="nonzero" transform="translate(3.511682, 5.998096) rotate(90.000000) translate(-3.511682, -5.998096) " points="3.50766704 3.94097547 -1.7599524 9.50949248 -2.48641409 8.82228551 3.5070954 2.48641409 9.50977787 8.82200011 8.78385656 9.50977787"></polygon>
-    </g>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="icon" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="6px" height="10px" viewBox="0 0 6 10" style="enable-background:new 0 0 6 10;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<polygon points="6,5 1,10 0.3,9.3 4.6,5 0.3,0.7 1,0 "/>
+<rect id="_x3C_Transparent_Rectangle_x3E_" class="st0" width="6" height="10"/>
 </svg>

--- a/packages/icons/src/svg/chevron--up.svg
+++ b/packages/icons/src/svg/chevron--up.svg
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="12px" height="7px" viewBox="0 0 12 7" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 50.2 (55047) - http://www.bohemiancoding.com/sketch -->
-    <title>chevron--up</title>
-    <desc>Created with Sketch.</desc>
-    <defs></defs>
-    <g id="chevron--up" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <polygon id="chevron" fill="#000000" fill-rule="nonzero" points="5.99408113 1.44972267 0.726461685 6.99971556 -5.79924997e-13 6.31479463 5.99350948 2.93098879e-14 11.996192 6.31451019 11.2702706 7"></polygon>
-    </g>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="icon" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="10px" height="6px" viewBox="0 0 10 6" style="enable-background:new 0 0 10 6;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<polygon points="5,0 10,5 9.3,5.7 5,1.4 0.7,5.7 0,5 "/>
+<rect id="_x3C_Transparent_Rectangle_x3E_" class="st0" width="10" height="6"/>
 </svg>


### PR DESCRIPTION
Replaced cv9 style glyphs with IDL stye glyphs for caret--up, caret--down, caret--left, caret--right, chevron--up, chevron--down, chevron--left, chevron--right

Closes #

{{short description}}

#### Changelog

**New**

- {{new thing}}

**Changed**

- {{change thing}}

**Removed**

- {{removed thing}}
