### PR TITLE
fix: remove auto margin from grid

### DIFF
--- a/packages/grid/scss/_core.scss
+++ b/packages/grid/scss/_core.scss
@@ -7,8 +7,6 @@
 //----------------------------------------------------------------------------
 .#{$prefix}--grid {
   width: 100%;
-  margin-right: auto;
-  margin-left: auto;
 
   @each $name, $value in $breakpoints {
     @include breakpoint($name) {


### PR DESCRIPTION
Removes auto margin from grid, we shouldn't assume a user wants their grid centered. 