### PR TITLE
docs(readme): add alt example for importing icons not globally

### DIFF
--- a/packages/icons-vue/README.md
+++ b/packages/icons-vue/README.md
@@ -50,6 +50,19 @@ like to use. In our application, we can then use them by doing:
 </template>
 ```
 
+If you would rather not register icons globally, you can also import them into individual components.
+
+```js
+import { Bee32 } from '@carbon/icons-vue';
+
+export default {
+  name: 'MyComponent',
+  component: {
+    Bee32
+  }
+};
+```
+
 You can pass in props to any icon component for things like accessibility
 labels, custom classes, event handlers, and more. For example:
 


### PR DESCRIPTION
Closes #115

Adds an alternative example of how icons can be imported into individual components instead of being registered globally. This might be useful if an icon is only being used in a single component and in cases where components are being lazy-loaded into the application.

#### Changelog

**New**

- Example in README showcasing another way Carbon icons can be used in a Vue project
