### PR TITLE
fix(icon-helpers): use attributes correctly in toSVG

### DIFF
--- a/packages/icon-helpers/src/toSVG.js
+++ b/packages/icon-helpers/src/toSVG.js
@@ -6,8 +6,9 @@ import getAttributes from './getAttributes';
 export default function toSVG(descriptor) {
   const { elem = 'svg', attrs = {}, content = [] } = descriptor;
   const node = document.createElementNS('http://www.w3.org/2000/svg', elem);
+  const attributes = elem !== 'svg' ? attrs : getAttributes(attrs);
 
-  Object.keys(elem !== 'svg' ? attrs : getAttributes(attrs)).forEach(key => {
+  Object.keys(attributes).forEach(key => {
     node.setAttribute(key, attrs[key]);
   });
 


### PR DESCRIPTION
Closes #110 

#### Changelog

**New**

**Changed**

- `@carbon/icon-helpers`
  - Fix usage of `getAttributes`

**Removed**
