### PR TITLE
fix(grid): avoid name conflict with carbon-components library

### DIFF
--- a/packages/grid/scss/12.scss
+++ b/packages/grid/scss/12.scss
@@ -22,7 +22,7 @@ $breakpoints: map-merge(
       columns: 12,
     ),
   ),
-  $carbon-grid-breakpoints
+  $grid-element-breakpoints
 );
 
 // Default container class for a grid. Includes max-width for each breakpoint

--- a/packages/grid/scss/12.scss
+++ b/packages/grid/scss/12.scss
@@ -22,7 +22,7 @@ $breakpoints: map-merge(
       columns: 12,
     ),
   ),
-  $grid-breakpoints
+  $carbon-grid-breakpoints
 );
 
 // Default container class for a grid. Includes max-width for each breakpoint

--- a/packages/grid/scss/_col.scss
+++ b/packages/grid/scss/_col.scss
@@ -62,7 +62,7 @@
 }
 
 @mixin make-grid-columns(
-  $breakpoints: $carbon-grid-breakpoints,
+  $breakpoints: $grid-element-breakpoints,
   $gutter: $grid-gutter
 ) {
   .#{$prefix}--col {

--- a/packages/grid/scss/_col.scss
+++ b/packages/grid/scss/_col.scss
@@ -62,7 +62,7 @@
 }
 
 @mixin make-grid-columns(
-  $breakpoints: $grid-breakpoints,
+  $breakpoints: $carbon-grid-breakpoints,
   $gutter: $grid-gutter
 ) {
   .#{$prefix}--col {

--- a/packages/grid/scss/_container.scss
+++ b/packages/grid/scss/_container.scss
@@ -7,7 +7,7 @@
 
 /// Create the container for a grid. Will cause full-bleed for the grid unless
 /// max-width properties are added with `make-container-max-widths`
-@mixin make-container($breakpoints: $carbon-grid-breakpoints) {
+@mixin make-container($breakpoints: $grid-element-breakpoints) {
   width: 100%;
   margin-right: auto;
   margin-left: auto;
@@ -34,7 +34,7 @@
 }
 
 /// Add in the max-widths for each breakpoint to the container
-@mixin make-container-max-widths($breakpoints: $carbon-grid-breakpoints) {
+@mixin make-container-max-widths($breakpoints: $grid-element-breakpoints) {
   @each $name, $value in $breakpoints {
     @include breakpoint($name) {
       max-width: map-get($value, width);

--- a/packages/grid/scss/_container.scss
+++ b/packages/grid/scss/_container.scss
@@ -7,7 +7,7 @@
 
 /// Create the container for a grid. Will cause full-bleed for the grid unless
 /// max-width properties are added with `make-container-max-widths`
-@mixin make-container($breakpoints: $grid-breakpoints) {
+@mixin make-container($breakpoints: $carbon-grid-breakpoints) {
   width: 100%;
   margin-right: auto;
   margin-left: auto;
@@ -34,7 +34,7 @@
 }
 
 /// Add in the max-widths for each breakpoint to the container
-@mixin make-container-max-widths($breakpoints: $grid-breakpoints) {
+@mixin make-container-max-widths($breakpoints: $carbon-grid-breakpoints) {
   @each $name, $value in $breakpoints {
     @include breakpoint($name) {
       max-width: map-get($value, width);

--- a/packages/grid/scss/grid.scss
+++ b/packages/grid/scss/grid.scss
@@ -20,4 +20,4 @@
   @include make-row();
 }
 
-@include make-grid-columns($carbon-grid-breakpoints, $grid-gutter);
+@include make-grid-columns($grid-element-breakpoints, $grid-gutter);

--- a/packages/grid/scss/grid.scss
+++ b/packages/grid/scss/grid.scss
@@ -20,4 +20,4 @@
   @include make-row();
 }
 
-@include make-grid-columns($grid-breakpoints, $grid-gutter);
+@include make-grid-columns($carbon-grid-breakpoints, $grid-gutter);

--- a/packages/layout/scss/_breakpoint.scss
+++ b/packages/layout/scss/_breakpoint.scss
@@ -5,7 +5,7 @@ $grid-cell-padding: rem(16px);
 $grid-gutter: rem(32px);
 
 // Initial map of our breakpoints and their values
-$grid-breakpoints: (
+$carbon-grid-breakpoints: (
   sm: (
     columns: 4,
     margin: 0,
@@ -41,7 +41,7 @@ $grid-breakpoints: (
 /// @returns {String}
 @function breakpoint-next(
   $name,
-  $breakpoints: $grid-breakpoints,
+  $breakpoints: $carbon-grid-breakpoints,
   $breakpoint-names: map-keys($breakpoints)
 ) {
   $n: index($breakpoint-names, $name);
@@ -53,7 +53,7 @@ $grid-breakpoints: (
 
 @function breakpoint-prev(
   $name,
-  $breakpoints: $grid-breakpoints,
+  $breakpoints: $carbon-grid-breakpoints,
   $breakpoint-names: map-keys($breakpoints)
 ) {
   $n: index($breakpoint-names, $name);
@@ -64,7 +64,10 @@ $grid-breakpoints: (
 }
 
 /// Check to see if the given breakpoint name
-@function is-smallest-breakpoint($name, $breakpoints: $grid-breakpoints) {
+@function is-smallest-breakpoint(
+  $name,
+  $breakpoints: $carbon-grid-breakpoints
+) {
   @return index(map-keys($breakpoints), $name) == 1;
 }
 
@@ -79,7 +82,7 @@ $grid-breakpoints: (
 /// Generate a media query up to the width of the given breakpoint name
 /// @param {string} $name
 /// @content
-@mixin breakpoint-up($name, $breakpoints: $grid-breakpoints) {
+@mixin breakpoint-up($name, $breakpoints: $carbon-grid-breakpoints) {
   $breakpoint: map-get($breakpoints, $name);
   $width: map-get($breakpoint, width);
 
@@ -99,7 +102,7 @@ $grid-breakpoints: (
 /// Generate a media query for the maximum width of the given styles
 /// @param {string} $name
 /// @content
-@mixin breakpoint-down($name, $breakpoints: $grid-breakpoints) {
+@mixin breakpoint-down($name, $breakpoints: $carbon-grid-breakpoints) {
   $breakpoint: map-get($breakpoints, $name);
   $width: map-get($breakpoint, width);
   @if map-has-key($breakpoints, $name) {
@@ -120,7 +123,11 @@ $grid-breakpoints: (
 /// @param {string} $lower
 /// @param {string} $upper
 /// @content
-@mixin breakpoint-between($lower, $upper, $breakpoints: $grid-breakpoints) {
+@mixin breakpoint-between(
+  $lower,
+  $upper,
+  $breakpoints: $carbon-grid-breakpoints
+) {
   $min: map-get($breakpoints, $lower);
   $max: map-get($breakpoints, $upper);
 
@@ -144,7 +151,7 @@ $grid-breakpoints: (
 /// Generate a media query for a given breakpoint
 /// @param {string} $breakpoint
 /// @content
-@mixin breakpoint($name, $breakpoints: $grid-breakpoints) {
+@mixin breakpoint($name, $breakpoints: $carbon-grid-breakpoints) {
   @include breakpoint-up($name, $breakpoints) {
     @content;
   }

--- a/packages/layout/scss/_breakpoint.scss
+++ b/packages/layout/scss/_breakpoint.scss
@@ -5,7 +5,7 @@ $grid-cell-padding: rem(16px);
 $grid-gutter: rem(32px);
 
 // Initial map of our breakpoints and their values
-$carbon-grid-breakpoints: (
+$grid-element-breakpoints: (
   sm: (
     columns: 4,
     margin: 0,
@@ -41,7 +41,7 @@ $carbon-grid-breakpoints: (
 /// @returns {String}
 @function breakpoint-next(
   $name,
-  $breakpoints: $carbon-grid-breakpoints,
+  $breakpoints: $grid-element-breakpoints,
   $breakpoint-names: map-keys($breakpoints)
 ) {
   $n: index($breakpoint-names, $name);
@@ -53,7 +53,7 @@ $carbon-grid-breakpoints: (
 
 @function breakpoint-prev(
   $name,
-  $breakpoints: $carbon-grid-breakpoints,
+  $breakpoints: $grid-element-breakpoints,
   $breakpoint-names: map-keys($breakpoints)
 ) {
   $n: index($breakpoint-names, $name);
@@ -66,7 +66,7 @@ $carbon-grid-breakpoints: (
 /// Check to see if the given breakpoint name
 @function is-smallest-breakpoint(
   $name,
-  $breakpoints: $carbon-grid-breakpoints
+  $breakpoints: $grid-element-breakpoints
 ) {
   @return index(map-keys($breakpoints), $name) == 1;
 }
@@ -82,7 +82,7 @@ $carbon-grid-breakpoints: (
 /// Generate a media query up to the width of the given breakpoint name
 /// @param {string} $name
 /// @content
-@mixin breakpoint-up($name, $breakpoints: $carbon-grid-breakpoints) {
+@mixin breakpoint-up($name, $breakpoints: $grid-element-breakpoints) {
   $breakpoint: map-get($breakpoints, $name);
   $width: map-get($breakpoint, width);
 
@@ -102,7 +102,7 @@ $carbon-grid-breakpoints: (
 /// Generate a media query for the maximum width of the given styles
 /// @param {string} $name
 /// @content
-@mixin breakpoint-down($name, $breakpoints: $carbon-grid-breakpoints) {
+@mixin breakpoint-down($name, $breakpoints: $grid-element-breakpoints) {
   $breakpoint: map-get($breakpoints, $name);
   $width: map-get($breakpoint, width);
   @if map-has-key($breakpoints, $name) {
@@ -126,7 +126,7 @@ $carbon-grid-breakpoints: (
 @mixin breakpoint-between(
   $lower,
   $upper,
-  $breakpoints: $carbon-grid-breakpoints
+  $breakpoints: $grid-element-breakpoints
 ) {
   $min: map-get($breakpoints, $lower);
   $max: map-get($breakpoints, $upper);
@@ -151,7 +151,7 @@ $carbon-grid-breakpoints: (
 /// Generate a media query for a given breakpoint
 /// @param {string} $breakpoint
 /// @content
-@mixin breakpoint($name, $breakpoints: $carbon-grid-breakpoints) {
+@mixin breakpoint($name, $breakpoints: $grid-element-breakpoints) {
   @include breakpoint-up($name, $breakpoints) {
     @content;
   }

--- a/packages/layout/scss/_key-height.scss
+++ b/packages/layout/scss/_key-height.scss
@@ -5,7 +5,10 @@
 /// heights
 /// @param {string} $breakpoint
 /// @return rem
-@function get-column-width($breakpoint, $breakpoints: $grid-breakpoints) {
+@function get-column-width(
+  $breakpoint,
+  $breakpoints: $carbon-grid-breakpoints
+) {
   @if map-has-key($breakpoints, $breakpoint) {
     $values: map-get($breakpoints, $breakpoint);
     $width: map-get($values, width);

--- a/packages/layout/scss/_key-height.scss
+++ b/packages/layout/scss/_key-height.scss
@@ -7,7 +7,7 @@
 /// @return rem
 @function get-column-width(
   $breakpoint,
-  $breakpoints: $carbon-grid-breakpoints
+  $breakpoints: $grid-element-breakpoints
 ) {
   @if map-has-key($breakpoints, $breakpoint) {
     $values: map-get($breakpoints, $breakpoint);

--- a/packages/type/scss/_styles.scss
+++ b/packages/type/scss/_styles.scss
@@ -382,7 +382,7 @@ $tokens: (
 ///
 /// @param {Map} $type-styles - the value of a given type token
 /// @param {?Map} $breakpoints - custom breakpoints to use
-@mixin fluid-type($type-styles, $breakpoints: $grid-breakpoints) {
+@mixin fluid-type($type-styles, $breakpoints: $carbon-grid-breakpoints) {
   & {
     // Include the initial styles for the given token by default without any
     // media query guard. This includes `font-size` as a fallback in the case
@@ -409,7 +409,11 @@ $tokens: (
 /// @param {String} $name - the name of the breakpoint to which we apply the fluid
 /// styles
 /// @param {?Map} $breakpoints - the breakpoints for the grid system
-@mixin fluid-type-size($type-styles, $name, $breakpoints: $grid-breakpoints) {
+@mixin fluid-type-size(
+  $type-styles,
+  $name,
+  $breakpoints: $carbon-grid-breakpoints
+) {
   // Get the information about the breakpoint we're currently working in. Useful
   // for getting initial width information
   $breakpoint: map-get($breakpoints, $name);
@@ -490,7 +494,11 @@ $tokens: (
 /// @param {?Boolean} $fluid - specify whether to include fluid styles for the
 /// @param {?Map} $breakpoints - provide a custom breakpoint map to use
 /// token
-@mixin type-style($name, $fluid: false, $breakpoints: $grid-breakpoints) {
+@mixin type-style(
+  $name,
+  $fluid: false,
+  $breakpoints: $carbon-grid-breakpoints
+) {
   @if not map-has-key($tokens, $name) {
     @error 'Unable to find a token with the name: `#{$name}`';
   }

--- a/packages/type/scss/_styles.scss
+++ b/packages/type/scss/_styles.scss
@@ -382,7 +382,7 @@ $tokens: (
 ///
 /// @param {Map} $type-styles - the value of a given type token
 /// @param {?Map} $breakpoints - custom breakpoints to use
-@mixin fluid-type($type-styles, $breakpoints: $carbon-grid-breakpoints) {
+@mixin fluid-type($type-styles, $breakpoints: $grid-element-breakpoints) {
   & {
     // Include the initial styles for the given token by default without any
     // media query guard. This includes `font-size` as a fallback in the case
@@ -412,7 +412,7 @@ $tokens: (
 @mixin fluid-type-size(
   $type-styles,
   $name,
-  $breakpoints: $carbon-grid-breakpoints
+  $breakpoints: $grid-element-breakpoints
 ) {
   // Get the information about the breakpoint we're currently working in. Useful
   // for getting initial width information
@@ -497,7 +497,7 @@ $tokens: (
 @mixin type-style(
   $name,
   $fluid: false,
-  $breakpoints: $carbon-grid-breakpoints
+  $breakpoints: $grid-element-breakpoints
 ) {
   @if not map-has-key($tokens, $name) {
     @error 'Unable to find a token with the name: `#{$name}`';


### PR DESCRIPTION
Refs IBM/carbon-components#1540. From the discussion in https://github.com/IBM/carbon-components/pull/1541#discussion_r239869566.

This change avoids name conflict in `carbon-components`
library where new grid code and old grid code (below) live together:
https://github.com/IBM/carbon-components/blob/v9.61.0/src/globals/grid/classic/_classic.scss#L6-L12

#### Changelog

**Changed**

- Replaced `$grid-breakpoints` with `$carbon-grid-breakpoints`