### PR TITLE
Fix icon blurriness issue in Firefox Quantum

### DIFF
--- a/packages/icon-helpers/src/getAttributes.js
+++ b/packages/icon-helpers/src/getAttributes.js
@@ -1,10 +1,13 @@
-const defaultAttributes = {
+export const defaultAttributes = {
   // Reference:
   // https://github.com/IBM/carbon-components-react/issues/1392
   // https://github.com/PolymerElements/iron-iconset-svg/pull/47
   // `focusable` is a string attribute which is why we do not use a boolean here
   focusable: 'false',
   preserveAspectRatio: 'xMidYMid meet',
+  // Reference:
+  // https://github.com/ckeditor/ckeditor5/issues/668#issuecomment-344844027
+  style: 'transform: translate3d(0, 0, 0);',
 };
 
 /**

--- a/packages/icon-helpers/src/index.js
+++ b/packages/icon-helpers/src/index.js
@@ -1,5 +1,5 @@
-import getAttributes from './getAttributes';
+import getAttributes, { defaultAttributes } from './getAttributes';
 import toString, { formatAttributes } from './toString';
 import toSVG from './toSVG';
 
-export { getAttributes, formatAttributes, toString, toSVG };
+export { defaultAttributes, getAttributes, formatAttributes, toString, toSVG };

--- a/packages/icons-react/src/createFromInfo.js
+++ b/packages/icons-react/src/createFromInfo.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { defaultAttributes } = require('@carbon/icon-helpers');
 const { camelCase } = require('change-case');
 const prettier = require('prettier');
 
@@ -14,6 +15,10 @@ const MODULE_IMPORTS = `
 import { getAttributes } from '@carbon/icon-helpers';
 import PropTypes from 'prop-types';
 import React from 'react';
+
+const defaultStyle = ${JSON.stringify(
+  transformStyleIntoObject(defaultAttributes.style)
+)};
 `;
 
 function createEntrypointFromMeta(meta) {
@@ -57,7 +62,7 @@ function iconToString(descriptor) {
 
 function createComponentFromInfo({ descriptor, moduleName }) {
   const source = `
-function ${moduleName}({ className, children, tabIndex, ...rest }) {
+function ${moduleName}({ className, children, style, tabIndex, ...rest }) {
   const { tabindex, ...props } = getAttributes({
     ...rest,
     tabindex: tabIndex,
@@ -69,6 +74,15 @@ function ${moduleName}({ className, children, tabIndex, ...rest }) {
 
   if (tabindex !== undefined && tabindex !== null) {
     props.tabIndex = tabindex;
+  }
+
+  if (typeof style === 'object') {
+    props.style = {
+      ...defaultStyle,
+      ...style,
+    };
+  } else {
+    props.style = defaultStyle;
   }
 
   return React.createElement(
@@ -102,6 +116,16 @@ ${moduleName}.defaultProps = {
   preserveAspectRatio: 'xMidYMid meet',
 };`;
   return prettier.format(source, prettierOptions);
+}
+
+function transformStyleIntoObject(string) {
+  return string.split(';').reduce((acc, declaration) => {
+    const [property, value] = declaration.split(':').map(s => s.trim());
+    return {
+      ...acc,
+      [property]: value,
+    };
+  }, {});
 }
 
 module.exports = {

--- a/packages/icons/examples/esm/index.js
+++ b/packages/icons/examples/esm/index.js
@@ -1,3 +1,4 @@
+import { getAttributes } from '@carbon/icon-helpers';
 import React, { useState } from 'react';
 import ReactDOM from 'react-dom';
 import meta from '../../meta.json';
@@ -122,7 +123,33 @@ function render() {
 
 function js2svg(descriptor) {
   const { elem, attrs = {}, content = [] } = descriptor;
-  return React.createElement(elem, format(attrs), ...content.map(js2svg));
+  let attributes = attrs;
+
+  if (elem === 'svg') {
+    const { style, ...iconAttributes } = getAttributes(attrs);
+    attributes = {
+      ...iconAttributes,
+      style: style
+        .split(';')
+        .map(declaration => {
+          const [property, value] = declaration
+            .split(':')
+            .map(string => string.trim());
+          return {
+            [property]: value,
+          };
+        })
+        .reduce(
+          (acc, declaration) => ({
+            ...acc,
+            ...declaration,
+          }),
+          {}
+        ),
+    };
+  }
+
+  return React.createElement(elem, format(attributes), ...content.map(js2svg));
 }
 
 function format(attrs) {


### PR DESCRIPTION
Came up today during icon review. 16x16 icons are blurry in Firefox Quantum, we need the custom `style` attribute added for each icon to prevent this.

#### Changelog

**New**

**Changed**

- `style` default attribute added to `@carbon/icon-helpers`
- Update implementations that need style objects, namely `@carbon/icons-react`

**Removed**
