### PR TITLE
Value update for expressive-heading-04 token

### DIFF
--- a/packages/type/scss/_styles.scss
+++ b/packages/type/scss/_styles.scss
@@ -123,16 +123,16 @@ $productive-heading-05: (
 
 $expressive-heading-04: (
   font-family: font-family('sans'),
-  font-size: type-scale(5),
+  font-size: type-scale(6),
   font-weight: font-weight('regular'),
   line-height: 130%,
   letter-spacing: 0,
   breakpoints: (
     md: (
-      font-size: type-scale(5),
+      font-size: type-scale(6),
     ),
     lg: (
-      font-size: type-scale(6),
+      font-size: type-scale(7),
       line-height: 125%,
     ),
     xlg: (

--- a/packages/type/src/__tests__/__snapshots__/styles-test.js.snap
+++ b/packages/type/src/__tests__/__snapshots__/styles-test.js.snap
@@ -283,14 +283,14 @@ exports[`styles expressiveHeading04 should be printable 1`] = `
 Object {
   "@media (min-width: 42rem)": Object {
     "fontFamily": "'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif",
-    "fontSize": "calc(1.25rem + 0.25 * ((100vw - 42rem) / 24))",
+    "fontSize": "calc(1.5rem + 0.25 * ((100vw - 42rem) / 24))",
     "fontWeight": 400,
     "letterSpacing": 0,
     "lineHeight": "1.625rem",
   },
   "@media (min-width: 66rem)": Object {
     "fontFamily": "'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif",
-    "fontSize": "calc(1.5rem + 0.25 * ((100vw - 66rem) / 16))",
+    "fontSize": "calc(1.75rem + 0 * ((100vw - 66rem) / 16))",
     "fontWeight": 400,
     "letterSpacing": 0,
     "lineHeight": "125%",
@@ -310,7 +310,7 @@ Object {
     "lineHeight": "125%",
   },
   "fontFamily": "'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif",
-  "fontSize": "calc(1.25rem + 0 * ((100vw - 20rem) / 22))",
+  "fontSize": "calc(1.5rem + 0 * ((100vw - 20rem) / 22))",
   "fontWeight": 400,
   "letterSpacing": 0,
   "lineHeight": "130%",
@@ -319,7 +319,7 @@ Object {
 
 exports[`styles expressiveHeading04 should be printable 2`] = `
 "font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
-font-size: calc(1.25rem + 0 * ((100vw - 20rem) / 22));
+font-size: calc(1.5rem + 0 * ((100vw - 20rem) / 22));
 font-weight: 400;
 line-height: 130%;
 letter-spacing: 0;

--- a/packages/type/src/styles.js
+++ b/packages/type/src/styles.js
@@ -125,20 +125,20 @@ export const productiveHeading05 = {
 
 export const expressiveHeading04 = fluid({
   fontFamily: fontFamilies.sans,
-  fontSize: rem(scale[4]),
+  fontSize: rem(scale[5]),
   fontWeight: fontWeights.regular,
   lineHeight: '130%',
   letterSpacing: 0,
   breakpoints: {
     md: {
-      fontSize: rem(scale[4]),
+      fontSize: rem(scale[5]),
       fontFamily: fontFamilies.sans,
       fontWeight: fontWeights.regular,
       lineHeight: rem(26),
       letterSpacing: 0,
     },
     lg: {
-      fontSize: rem(scale[5]),
+      fontSize: rem(scale[6]),
       fontFamily: fontFamilies.sans,
       fontWeight: fontWeights.regular,
       lineHeight: '125%',


### PR DESCRIPTION
expressive-heading-04 values at sm, med, and large breakpoints were updated in order to prevent our H1 and H2s from becoming that same size at mobile and tablet.

