### PR TITLE
feat(type): introduce an option to omit CSS classes

### DIFF
--- a/packages/type/scss/_classes.scss
+++ b/packages/type/scss/_classes.scss
@@ -10,7 +10,7 @@
 @import 'styles';
 @import 'font-family';
 
-@include exports('@carbon/type/scss/_classes.scss') {
+@mixin type--css-classes {
   // Font families
   @each $name, $value in $font-families {
     .#{$prefix}--type-#{$name} {
@@ -35,5 +35,15 @@
     .#{$prefix}--type-#{$name} {
       @include type-style($name, map-has-key($value, breakpoints));
     }
+  }
+}
+
+@include exports('@carbon/type/scss/_classes.scss') {
+  @if global-variable-exists('type--css-classes') ==
+    false or
+    $type--css-classes ==
+    true
+  {
+    @include type--css-classes;
   }
 }


### PR DESCRIPTION
Fixes #224.

#### Changelog

**New**

- `$type--css-class` Sass variable, which controls whether or not CSS classes of `@carbon/type` is included.