### PR TITLE
Revert to previous weights on several heading tokens

### DIFF
--- a/packages/type/src/styles.js
+++ b/packages/type/src/styles.js
@@ -140,21 +140,21 @@ export const expressiveHeading04 = fluid({
     lg: {
       fontSize: rem(scale[6]),
       fontFamily: fontFamilies.sans,
-      fontWeight: fontWeights.light,
+      fontWeight: fontWeights.regular,
       lineHeight: '125%',
       letterSpacing: 0,
     },
     xlg: {
       fontSize: rem(scale[6]),
       fontFamily: fontFamilies.sans,
-      fontWeight: fontWeights.light,
+      fontWeight: fontWeights.regular,
       lineHeight: '129%',
       letterSpacing: 0,
     },
     max: {
       fontSize: rem(scale[7]),
       fontFamily: fontFamilies.sans,
-      fontWeight: fontWeights.light,
+      fontWeight: fontWeights.regular,
       lineHeight: '125%',
       letterSpacing: 0,
     },
@@ -164,7 +164,7 @@ export const expressiveHeading04 = fluid({
 export const expressiveHeading05 = fluid({
   fontFamily: fontFamilies.sans,
   fontSize: rem(scale[6]),
-  fontWeight: fontWeights.light,
+  fontWeight: fontWeights.regular,
   lineHeight: '129%',
   letterSpacing: 0,
   breakpoints: {


### PR DESCRIPTION
There were conflicting weights on the IDL site; the brand team likes to use the light (300) weight on black backgrounds and regular (400) weight on light backgrounds for fonts of the same size. 

We have to pick a lane and stick with the Regular (400) weight for $expressive-heading-04 (all steps) $expressive-heading-05 (step 7) and $productive-heading-04. 

Basically reverting back to what we had before... apologize for the confusion!!!
