### PR TITLE
feat(icons-react): attach refs to rendered SVG icon components

### DIFF
--- a/packages/icons-react/src/__tests__/createFromInfo-test.js
+++ b/packages/icons-react/src/__tests__/createFromInfo-test.js
@@ -125,6 +125,18 @@ describe('createFromInfo', () => {
       }
     });
 
+    fit('should forward refs to rendered DOM element', async () => {
+      const moduleSource = createModuleFromInfo(info);
+      const MockIconComponent = await getModuleFromString(moduleSource);
+      let svg;
+      const ref = jest.fn(node => {
+        svg = node;
+      });
+      ReactDOM.render(<MockIconComponent ref={ref} />, mountNode);
+      expect(() => <MockIconComponent ref={ref} />).not.toThrow();
+      expect(svg === document.querySelector('svg'));
+    });
+
     it('should be focusable if an aria label and tab index is used', async () => {
       const moduleSource = createModuleFromInfo(info);
       const MockIconComponent = await getModuleFromString(moduleSource);

--- a/packages/icons-react/src/__tests__/createFromInfo-test.js
+++ b/packages/icons-react/src/__tests__/createFromInfo-test.js
@@ -133,7 +133,6 @@ describe('createFromInfo', () => {
         svg = node;
       });
       ReactDOM.render(<MockIconComponent ref={ref} />, mountNode);
-      expect(() => <MockIconComponent ref={ref} />).not.toThrow();
       expect(svg === document.querySelector('svg'));
     });
 

--- a/packages/icons-react/src/__tests__/createFromInfo-test.js
+++ b/packages/icons-react/src/__tests__/createFromInfo-test.js
@@ -125,7 +125,7 @@ describe('createFromInfo', () => {
       }
     });
 
-    fit('should forward refs to rendered DOM element', async () => {
+    it('should forward refs to rendered DOM element', async () => {
       const moduleSource = createModuleFromInfo(info);
       const MockIconComponent = await getModuleFromString(moduleSource);
       let svg;

--- a/packages/icons-react/src/createFromInfo.js
+++ b/packages/icons-react/src/createFromInfo.js
@@ -81,7 +81,13 @@ function iconToString(descriptor) {
 
 function createComponentFromInfo({ descriptor, moduleName }) {
   const source = `
-    const ${moduleName} = React.forwardRef(({ className, children, style, tabIndex, ...rest }, ref) => {
+    const ${moduleName} = React.forwardRef(({
+      className,
+      children,
+      style,
+      tabIndex,
+      ...rest,
+    }, ref) => {
       const { tabindex, ...props } = getAttributes({
         ...rest,
         tabindex: tabIndex,
@@ -114,7 +120,7 @@ function createComponentFromInfo({ descriptor, moduleName }) {
         children,
         ${descriptor.content.map(iconToString).join(', ')}
       );
-    })
+    });
     ${moduleName}.displayName = '${moduleName}';
     ${moduleName}.propTypes = {
       'aria-hidden': PropTypes.bool,

--- a/packages/icons-react/src/createFromInfo.js
+++ b/packages/icons-react/src/createFromInfo.js
@@ -81,59 +81,63 @@ function iconToString(descriptor) {
 
 function createComponentFromInfo({ descriptor, moduleName }) {
   const source = `
-function ${moduleName}({ className, children, style, tabIndex, ...rest }) {
-  const { tabindex, ...props } = getAttributes({
-    ...rest,
-    tabindex: tabIndex,
-  });
+    const ${moduleName} = React.forwardRef(({ className, children, style, tabIndex, ...rest }, ref) => {
+      const { tabindex, ...props } = getAttributes({
+        ...rest,
+        tabindex: tabIndex,
+      });
 
-  if (className) {
-    props.className = className;
-  }
+      if (className) {
+        props.className = className;
+      }
 
-  if (tabindex !== undefined && tabindex !== null) {
-    props.tabIndex = tabindex;
-  }
+      if (tabindex !== undefined && tabindex !== null) {
+        props.tabIndex = tabindex;
+      }
 
-  if (typeof style === 'object') {
-    props.style = {
-      ...defaultStyle,
-      ...style,
+      if (typeof style === 'object') {
+        props.style = {
+          ...defaultStyle,
+          ...style,
+        };
+      } else {
+        props.style = defaultStyle;
+      }
+
+      if (ref) {
+        props.ref = ref;
+      }
+
+      return React.createElement(
+        'svg',
+        props,
+        children,
+        ${descriptor.content.map(iconToString).join(', ')}
+      );
+    })
+    ${moduleName}.displayName = '${moduleName}';
+    ${moduleName}.propTypes = {
+      'aria-hidden': PropTypes.bool,
+      'aria-label': PropTypes.string,
+      'aria-labelledby': PropTypes.string,
+      className: PropTypes.string,
+      children: PropTypes.node,
+      height: PropTypes.number,
+      preserveAspectRatio: PropTypes.string,
+      tabIndex: PropTypes.string,
+      title: PropTypes.string,
+      viewBox: PropTypes.string,
+      width: PropTypes.number,
+      xmlns: PropTypes.string,
     };
-  } else {
-    props.style = defaultStyle;
-  }
-
-  return React.createElement(
-    'svg',
-    props,
-    children,
-    ${descriptor.content.map(iconToString).join(', ')}
-  );
-}
-
-${moduleName}.displayName = '${moduleName}';
-${moduleName}.propTypes = {
-  'aria-hidden': PropTypes.bool,
-  'aria-label': PropTypes.string,
-  'aria-labelledby': PropTypes.string,
-  className: PropTypes.string,
-  children: PropTypes.node,
-  height: PropTypes.number,
-  preserveAspectRatio: PropTypes.string,
-  tabIndex: PropTypes.string,
-  title: PropTypes.string,
-  viewBox: PropTypes.string,
-  width: PropTypes.number,
-  xmlns: PropTypes.string,
-};
-${moduleName}.defaultProps = {
-  width: ${descriptor.attrs.width},
-  height: ${descriptor.attrs.height},
-  viewBox: '${descriptor.attrs.viewBox}',
-  xmlns: 'http://www.w3.org/2000/svg',
-  preserveAspectRatio: 'xMidYMid meet',
-};`;
+    ${moduleName}.defaultProps = {
+      width: ${descriptor.attrs.width},
+      height: ${descriptor.attrs.height},
+      viewBox: '${descriptor.attrs.viewBox}',
+      xmlns: 'http://www.w3.org/2000/svg',
+      preserveAspectRatio: 'xMidYMid meet',
+    };
+  `;
   return prettier.format(source, prettierOptions);
 }
 


### PR DESCRIPTION
Closes #228 

This PR uses `React.forwardRef` to preserve React refs on the rendered SVG

#### Changelog

**Changed**

- wrap icon modules with `React.forwardRef`