### PR TITLE
fix(icon-handlebars): update exports pattern

### DIFF
--- a/packages/icons-handlebars/index.js
+++ b/packages/icons-handlebars/index.js
@@ -30,7 +30,7 @@ function iconHelper(name, { hash = {} } = {}) {
   );
 }
 
-module.exports = function register({ handlebars }) {
+module.exports = exports = function register({ handlebars }) {
   return handlebars.registerHelper('carbon-icon', iconHelper);
 };
 exports.iconHelper = iconHelper;


### PR DESCRIPTION
Update export pattern for `icons-handlebars` to correctly export `iconHelper`

#### Changelog

**New**

**Changed**

- `@carbon/icons-handlebars`
  - Update export pattern

**Removed**
