### PR TITLE
Adds the ability to pass an object to carbon-icon handlebars helper

### DIFF
--- a/packages/icons-handlebars/index.js
+++ b/packages/icons-handlebars/index.js
@@ -15,7 +15,7 @@ const {
 } = require('@carbon/icon-helpers');
 const { SafeString } = require('handlebars');
 
-function iconHelper(name, attributes = {}) {
+function iconHelper(name, attributes = {}, options = {}) {
   const icon = CarbonIcons[name];
   if (!icon) {
     throw new Error(`Unable to find the icon: \`${name}\``);
@@ -23,7 +23,7 @@ function iconHelper(name, attributes = {}) {
   const content = icon.content.map(toString);
   const attrs = {
     ...icon.attrs,
-    ...(attributes.hash || attributes),
+    ...Object.assign({}, attributes.hash || attributes, options.hash),
   };
   return new SafeString(
     `<svg ${formatAttributes(getAttributes(attrs))}>${content.join('')}</svg>`

--- a/packages/icons-handlebars/index.js
+++ b/packages/icons-handlebars/index.js
@@ -15,7 +15,7 @@ const {
 } = require('@carbon/icon-helpers');
 const { SafeString } = require('handlebars');
 
-function iconHelper(name, { hash = {} } = {}) {
+function iconHelper(name, attributes = {}) {
   const icon = CarbonIcons[name];
   if (!icon) {
     throw new Error(`Unable to find the icon: \`${name}\``);
@@ -23,7 +23,7 @@ function iconHelper(name, { hash = {} } = {}) {
   const content = icon.content.map(toString);
   const attrs = {
     ...icon.attrs,
-    ...hash,
+    ...(attributes.hash || attributes),
   };
   return new SafeString(
     `<svg ${formatAttributes(getAttributes(attrs))}>${content.join('')}</svg>`


### PR DESCRIPTION
Closes #256 

#### Changelog

**Changed**

- iconHelper tests parameter to determine if `hash` property exists to use the conventional handlebars input or it's a custom object and the full object should be used to apply attributes to an icon.
