### PR TITLE
fix(themes): add in deprecated tokens

### DIFF
--- a/packages/colors/__tests__/__snapshots__/colors-test.js.snap
+++ b/packages/colors/__tests__/__snapshots__/colors-test.js.snap
@@ -136,5 +136,3 @@ Object {
   },
 }
 `;
-
-exports[`tokens 1`] = `undefined`;

--- a/packages/colors/__tests__/__snapshots__/colors-test.js.snap
+++ b/packages/colors/__tests__/__snapshots__/colors-test.js.snap
@@ -2,6 +2,9 @@
 
 exports[`colors 1`] = `
 Object {
+  "black": Object {
+    "100": "#000000",
+  },
   "blue": Object {
     "10": "#edf4ff",
     "100": "#051243",
@@ -74,6 +77,9 @@ Object {
     "80": "#760a3a",
     "90": "#57002b",
   },
+  "orange": Object {
+    "40": "#fc7b1e",
+  },
   "purple": Object {
     "10": "#f7f1ff",
     "100": "#1e1033",
@@ -122,51 +128,13 @@ Object {
     "80": "#403c3c",
     "90": "#2b2828",
   },
+  "white": Object {
+    "0": "#ffffff",
+  },
+  "yellow": Object {
+    "20": "#fdd13a",
+  },
 }
 `;
 
-exports[`tokens 1`] = `
-Object {
-  "activeDanger": "#750e13",
-  "activePrimary": "#0530ad",
-  "activeSecondary": "#6f6f6f",
-  "activeUI": "#bebebe",
-  "brand01": "#0062ff",
-  "brand02": "#0062ff",
-  "brand03": "#0062ff",
-  "disabled01": "#f3f3f3",
-  "disabled02": "#bebebe",
-  "disabled03": "#8c8c8c",
-  "field01": "#f3f3f3",
-  "field02": "#ffffff",
-  "focus": "#0062ff",
-  "hoverDanger": "#ba1b23",
-  "hoverPrimary": "#0353e9",
-  "hoverPrimaryText": "#054ada",
-  "hoverRow": "#e5e5e5",
-  "hoverSecondary": "#4c4c4c",
-  "hoverUI": "#e5e5e5",
-  "icon01": "#171717",
-  "icon02": "#565656",
-  "interactive01": "#0062ff",
-  "interactive02": "#0062ff",
-  "inverse01": "#ffffff",
-  "inverse02": "#3d3d3d",
-  "overlay01": "rgba(255, 255, 255, 0.6)",
-  "overlay02": "rgba(243, 243, 243, 0.7)",
-  "selectedUI": "#dcdcdc",
-  "support01": "#da1e28",
-  "support02": "#198038",
-  "support03": "#fdd13a",
-  "support04": "#054ada",
-  "text01": "#171717",
-  "text02": "#565656",
-  "text03": "#8c8c8c",
-  "ui01": "#f3f3f3",
-  "ui02": "#ffffff",
-  "ui03": "#dcdcdc",
-  "ui04": "#8c8c8c",
-  "ui05": "#171717",
-  "visitedLink": "#8a3ffc",
-}
-`;
+exports[`tokens 1`] = `undefined`;

--- a/packages/colors/__tests__/colors-test.js
+++ b/packages/colors/__tests__/colors-test.js
@@ -9,12 +9,8 @@
 
 'use strict';
 
-import { colors, tokens } from '../src';
+import { colors } from '../src';
 
 test('colors', () => {
   expect(colors).toMatchSnapshot();
-});
-
-test('tokens', () => {
-  expect(tokens).toMatchSnapshot();
 });

--- a/packages/themes/src/__tests__/themes-test.js
+++ b/packages/themes/src/__tests__/themes-test.js
@@ -74,6 +74,13 @@ const tokens = new Set([
   'disabled01',
   'disabled02',
   'disabled03',
+
+  // Deprecated
+  'brand01',
+  'brand02',
+  'brand03',
+  'active01',
+  'hoverField',
 ]);
 
 describe('themes', () => {

--- a/packages/themes/src/g10.js
+++ b/packages/themes/src/g10.js
@@ -103,3 +103,5 @@ export const disabled03 = gray50;
 export const brand01 = interactive01;
 export const brand02 = interactive02;
 export const brand03 = interactive03;
+export const active01 = activeUI;
+export const hoverField = hoverUI;

--- a/packages/themes/src/g100.js
+++ b/packages/themes/src/g100.js
@@ -103,3 +103,5 @@ export const disabled03 = gray60;
 export const brand01 = interactive01;
 export const brand02 = interactive02;
 export const brand03 = interactive03;
+export const active01 = activeUI;
+export const hoverField = hoverUI;

--- a/packages/themes/src/g90.js
+++ b/packages/themes/src/g90.js
@@ -104,3 +104,5 @@ export const disabled03 = gray50;
 export const brand01 = interactive01;
 export const brand02 = interactive02;
 export const brand03 = interactive03;
+export const active01 = activeUI;
+export const hoverField = hoverUI;

--- a/packages/themes/src/white.js
+++ b/packages/themes/src/white.js
@@ -107,3 +107,5 @@ export const disabled03 = gray50;
 export const brand01 = interactive01;
 export const brand02 = interactive02;
 export const brand03 = interactive03;
+export const active01 = activeUI;
+export const hoverField = hoverUI;

--- a/packages/type/src/__tests__/__snapshots__/styles-test.js.snap
+++ b/packages/type/src/__tests__/__snapshots__/styles-test.js.snap
@@ -291,21 +291,21 @@ Object {
   "@media (min-width: 66rem)": Object {
     "fontFamily": "'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif",
     "fontSize": "calc(1.75rem + 0 * ((100vw - 66rem) / 16))",
-    "fontWeight": 300,
+    "fontWeight": 400,
     "letterSpacing": 0,
     "lineHeight": "125%",
   },
   "@media (min-width: 82rem)": Object {
     "fontFamily": "'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif",
     "fontSize": "calc(1.75rem + 0.25 * ((100vw - 82rem) / 17))",
-    "fontWeight": 300,
+    "fontWeight": 400,
     "letterSpacing": 0,
     "lineHeight": "129%",
   },
   "@media (min-width: 99rem)": Object {
     "fontFamily": "'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif",
     "fontSize": "2rem",
-    "fontWeight": 300,
+    "fontWeight": 400,
     "letterSpacing": 0,
     "lineHeight": "125%",
   },
@@ -361,7 +361,7 @@ Object {
   },
   "fontFamily": "'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif",
   "fontSize": "calc(1.75rem + 0.5 * ((100vw - 20rem) / 22))",
-  "fontWeight": 300,
+  "fontWeight": 400,
   "letterSpacing": 0,
   "lineHeight": "129%",
 }
@@ -370,7 +370,7 @@ Object {
 exports[`styles expressiveHeading05 should be printable 2`] = `
 "font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
 font-size: calc(1.75rem + 0.5 * ((100vw - 20rem) / 22));
-font-weight: 300;
+font-weight: 400;
 line-height: 129%;
 letter-spacing: 0;
 -@media- -(min--width-:- -4-2rem-): [object Object];

--- a/tasks/ci-check.js
+++ b/tasks/ci-check.js
@@ -30,12 +30,13 @@ async function main() {
     clearInterval(interval);
     console.log();
     reporter.success('Done! ✨');
-  } catch (error) {
+  } finally {
     clearInterval(interval);
   }
 }
 
 main().catch(error => {
+  console.log();
   reporter.error(error.message);
   if (error.stdout !== '') {
     console.error(error.stdout);


### PR DESCRIPTION
Closes #262 

#### Changelog

**New**

**Changed**

- Add `active-01` and `hover-field` as deprecated tokens in `@carbon/themes`

**Removed**
