### PR TITLE
Xlg breakpoint tweak for $expressive-heading-04

### DIFF
--- a/packages/type/src/styles.js
+++ b/packages/type/src/styles.js
@@ -133,8 +133,15 @@ export const expressiveHeading04 = fluid({
     md: {
       lineHeight: '129%',
     },
+    lg: {
+      // ...
+    },
     xlg: {
-      fontSize: rem(scale[7]),
+      fontSize: rem(scale[6]),
+      lineHeight: '125%',
+    },
+    max: {
+        fontSize: rem(scale[7]),
       lineHeight: '125%',
     },
   },


### PR DESCRIPTION
Mike commented that the H2 type looked too big on a laptop at the Xlg breakpoint; so I'm taking it back to 28px (v. 32px) 