### PR TITLE
Make $expressive-paragraph-01 Light (not Reg)

### DIFF
--- a/packages/type/scss/_styles.scss
+++ b/packages/type/scss/_styles.scss
@@ -167,7 +167,7 @@ $expressive-heading-05: (
 $expressive-paragraph-01: (
   font-family: font-family('sans'),
   font-size: type-scale(6),
-  font-weight: font-weight('regular'),
+  font-weight: font-weight('light'),
   line-height: 125%,
   letter-spacing: 0,
   breakpoints: (

--- a/packages/type/src/__tests__/__snapshots__/styles-test.js.snap
+++ b/packages/type/src/__tests__/__snapshots__/styles-test.js.snap
@@ -361,7 +361,7 @@ exports[`styles expressiveParagraph01 should be printable 1`] = `
 Object {
   "fontFamily": "'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif",
   "fontSize": "1.5rem",
-  "fontWeight": 400,
+  "fontWeight": 300,
   "letterSpacing": 0,
   "lg": Object {
     "fontSize": "1.75rem",
@@ -378,7 +378,7 @@ Object {
 exports[`styles expressiveParagraph01 should be printable 2`] = `
 "font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
 font-size: 1.5rem;
-font-weight: 400;
+font-weight: 300;
 line-height: 125%;
 letter-spacing: 0;
 lg: [object Object];

--- a/packages/type/src/styles.js
+++ b/packages/type/src/styles.js
@@ -181,7 +181,7 @@ export const expressiveHeading05 = fluid({
 export const expressiveParagraph01 = fluid({
   fontFamily: fontFamilies.sans,
   fontSize: rem(scale[5]),
-  fontWeight: fontWeights.regular,
+  fontWeight: fontWeights.light,
   lineHeight: '125%',
   letterSpacing: 0,
   lg: {


### PR DESCRIPTION
Updating the expressive paragraph token to be light weight at all breakpoints. Meets the requirements for / design and mimics the use of this type style on the IDL site.

Light on the left (on IDL) looks much more pronounced with semi-bold than regular.

![image](https://user-images.githubusercontent.com/43144260/51549186-85499900-1e2f-11e9-927d-4f52a875ffba.png)
