### PR TITLE
fix(type): change font weight for strong

### DIFF
--- a/packages/type/scss/_reset.scss
+++ b/packages/type/scss/_reset.scss
@@ -23,4 +23,8 @@
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }
+
+  strong {
+    font-weight: 600;
+  }
 }

--- a/packages/type/src/reset.js
+++ b/packages/type/src/reset.js
@@ -20,4 +20,7 @@ export const reset = {
     '-webkit-font-smoothing': 'antialiased',
     '-moz-osx-font-smoothing': 'grayscale',
   },
+  strong: {
+    fontWeight: fontWeights.semibold,
+  },
 };


### PR DESCRIPTION
Closes #276
#### Changelog

**New**

**Changed**

- Update resets to use `font-weight: 600` for `strong` elements

**Removed**
