### PR TITLE
refactor(icons-react): remove unneeded propType declaration

### DIFF
--- a/packages/icons-react/src/createFromInfo.js
+++ b/packages/icons-react/src/createFromInfo.js
@@ -131,7 +131,6 @@ function createComponentFromInfo({ descriptor, moduleName }) {
       height: PropTypes.number,
       preserveAspectRatio: PropTypes.string,
       tabIndex: PropTypes.string,
-      title: PropTypes.string,
       viewBox: PropTypes.string,
       width: PropTypes.number,
       xmlns: PropTypes.string,


### PR DESCRIPTION
Closes #303

This PR removes the `title` property from the `propTypes` object