### PR TITLE
feat(themes): add highlight token

### DIFF
--- a/packages/themes/src/g10.js
+++ b/packages/themes/src/g10.js
@@ -7,6 +7,7 @@
 
 import {
   // Blue
+  blue20,
   blue60,
   blue70,
   blue80,
@@ -98,6 +99,8 @@ export const visitedLink = purple60;
 export const disabled01 = white;
 export const disabled02 = gray30;
 export const disabled03 = gray50;
+
+export const highlight = blue20;
 
 // Deprecated ☠️
 export const brand01 = interactive01;

--- a/packages/themes/src/g100.js
+++ b/packages/themes/src/g100.js
@@ -11,6 +11,7 @@ import {
   blue60,
   blue70,
   blue80,
+  blue90,
 
   // Gray
   gray10,
@@ -98,6 +99,8 @@ export const visitedLink = purple40;
 export const disabled01 = gray90;
 export const disabled02 = gray80;
 export const disabled03 = gray60;
+
+export const highlight = blue90;
 
 // Deprecated ☠️
 export const brand01 = interactive01;

--- a/packages/themes/src/g90.js
+++ b/packages/themes/src/g90.js
@@ -11,6 +11,7 @@ import {
   blue60,
   blue70,
   blue80,
+  blue90,
 
   // Gray
   gray10,
@@ -99,6 +100,8 @@ export const visitedLink = purple40;
 export const disabled01 = gray80;
 export const disabled02 = gray70;
 export const disabled03 = gray50;
+
+export const highlight = blue90;
 
 // Deprecated ☠️
 export const brand01 = interactive01;

--- a/packages/themes/src/white.js
+++ b/packages/themes/src/white.js
@@ -7,6 +7,7 @@
 
 import {
   // Blue
+  blue20,
   blue60,
   blue70,
   blue80,
@@ -102,6 +103,8 @@ export const visitedLink = purple60;
 export const disabled01 = gray10;
 export const disabled02 = gray30;
 export const disabled03 = gray50;
+
+export const highlight = blue20;
 
 // Deprecated ☠️
 export const brand01 = interactive01;


### PR DESCRIPTION
I propose adding a `$highlight` token per this comment here: https://github.com/IBM/carbon-components/issues/1710#issuecomment-459804553

cc @IBM/carbon-designers 

Currently `Datepicker` highlight is set directly with a color variable instead of a token. Unfortunately this color variable won't work for g90 and g100 themes.

So as it stands, the only way to fix this issue with the current `@carbon/themes` setup is to add a new token. This `$highlight` token will allow `DatePicker` to be updated in such a way that makes it a11y compliant for g90 and g100 themes.

#### Changelog

**New**

- add `$highlight` token

**Changed**

- set `$highlight` for each existing theme (blue20 for light themes, blue90 for dark ui themes like g90 and g100)