### PR TITLE
fix(elements): update type import to use bundle

### DIFF
--- a/packages/elements/scss/elements.scss
+++ b/packages/elements/scss/elements.scss
@@ -5,5 +5,5 @@
 @import './themes/themes';
 @import './layout/layout';
 @import './grid/grid';
-@import './type/type';
+@import './type/bundle';
 @import './motion/motion';


### PR DESCRIPTION
#### Changelog

**Changed**

- Use `bundle` instead of `type` for `@carbon/type` import to include the extra mixins

EDIT: a little extra context -- if one were to use `@carbon/elements` right now, they could not get some `type` essentials like the reset mixin, etc. (unless they included that mixin themselves in their project, which I don't believe is the intention of this package)