### PR TITLE
fix: parseFloat only has one parameter

### DIFF
--- a/packages/type/src/fluid.js
+++ b/packages/type/src/fluid.js
@@ -82,5 +82,5 @@ function fluidTypeSize(defaultStyles, fluidBreakpointName, fluidBreakpoints) {
 }
 
 function subtract(a, b) {
-  return parseFloat(a, 10) - parseFloat(b, 10);
+  return parseFloat(a) - parseFloat(b);
 }


### PR DESCRIPTION
It doesn't take a radix like parseInt does 🤷‍♂️
