### PR TITLE
fix(icons-angular): remove massive default entrypoint

### DIFF
--- a/packages/icons-angular/config/tsconfig-aot.json
+++ b/packages/icons-angular/config/tsconfig-aot.json
@@ -17,8 +17,8 @@
     "inlineSources": true,
     "typeRoots": ["./../node_modules/@types"]
   },
-  "files": [
-    "./../ts/index.ts"
+  "include": [
+    "./../ts/**/*"
   ],
   "angularCompilerOptions": {
     "strictMetadataEmit": true,

--- a/packages/icons-angular/src/build.js
+++ b/packages/icons-angular/src/build.js
@@ -9,14 +9,13 @@ const icons = require('@carbon/icons/meta.json');
 const { toString } = require('@carbon/icon-helpers');
 const { reporter } = require('@carbon/cli-reporter');
 const fs = require('fs-extra');
-const { join, dirname, resolve } = require('path');
+const { join, dirname } = require('path');
 const { param } = require('change-case');
 const ngc = require('@angular/compiler-cli/src/main');
 const { rollup } = require('rollup');
 const {
   componentTemplate,
   moduleTemplate,
-  indexTemplate,
   storyTemplate,
 } = require('./templates');
 const clean = require('./clean');
@@ -28,15 +27,12 @@ async function generateComponents() {
     const className = icon.moduleName;
     const selectorName = param(icon.moduleName);
     const rawSvg = toString(icon.descriptor);
-    const dirExists = await fs.exists(join(paths.TS, icon.basename));
     const outputPath = icon.outputOptions.file
       .replace('es', 'ts')
       .replace('.js', '.ts');
     // try to write out the component
     try {
-      if (!dirExists) {
-        await fs.ensureDir(dirname(outputPath));
-      }
+      await fs.ensureDir(dirname(outputPath));
       await fs.writeFile(
         outputPath,
         componentTemplate(
@@ -50,31 +46,9 @@ async function generateComponents() {
       reporter.error(err);
     }
   }
-  // write out the module
-  // try {
-  // await fs.writeFile(join(paths.TS, 'IconModule.ts'), moduleTemplate(icons));
-  // await fs.writeFile(join(paths.TS, 'index.ts'), indexTemplate());
-  // } catch (err) {
-  // reporter.log(err);
-  // }
 }
 
 async function buildUMD() {
-  const bundle = await rollup({
-    input: join(paths.LIB, 'index.js'),
-    external: ['@angular/core', '@carbon/icon-helpers'],
-  });
-
-  await bundle.write({
-    name: 'CarbonIconsAngular',
-    format: 'umd',
-    file: join(paths.UMD, 'index.js'),
-    globals: {
-      '@carbon/icon-helpers': 'CarbonIconHelpers',
-      '@angular/core': 'ng.Core',
-    },
-  });
-
   for (const icon of icons) {
     const jsSource = icon.outputOptions.file.replace('es', 'lib');
     const iconbundle = await rollup({

--- a/packages/icons-angular/src/templates.js
+++ b/packages/icons-angular/src/templates.js
@@ -7,50 +7,6 @@
 
 const { param } = require('change-case');
 
-const formatImports = iconMeta => {
-  let value = '';
-  for (const icon of iconMeta) {
-    value += `import { ${
-      icon.moduleName
-    }Module } from "./${icon.outputOptions.file
-      .replace('es/', '')
-      .replace('.js', '')}";\n`;
-  }
-  return value;
-};
-
-const formatDeclarations = iconMeta => {
-  let value = '';
-  for (const icon of iconMeta) {
-    value += `${icon.moduleName}Module,\n`;
-  }
-  return value;
-};
-
-const indexTemplate = () => `
-export * from "./IconModule";
-`;
-
-const moduleTemplate = iconMeta => `
-import { NgModule } from "@angular/core";
-
-${formatImports(iconMeta)}
-
-@NgModule({
-	imports: [
-    ${formatDeclarations(iconMeta)}
-  ],
-	exports: [
-    ${formatDeclarations(iconMeta)}
-  ]
-})
-export class IconModule {}
-
-export {
-  ${formatDeclarations(iconMeta)}
-};
-`;
-
 const componentTemplate = (iconName, className, svg, attrs) => `
 import { NgModule, Component, ElementRef, Input } from "@angular/core";
 import { getAttributes } from "@carbon/icon-helpers";
@@ -155,8 +111,6 @@ storiesOf("${basename}", module)
 `;
 
 module.exports = {
-  moduleTemplate,
   componentTemplate,
-  indexTemplate,
   storyTemplate,
 };


### PR DESCRIPTION
closes #350 

Essentially just removes a whole bunch of dead code. since we were already building the `NgModule`s as part of the components, consumers just have to `import { SomeIconSizeModule } from "@carbon/icons-angular/lib/some-icon/size"` (Instead of importing the module directly from the index)