### PR TITLE
fix(themes): update support02 for g90 and g100

### DIFF
--- a/packages/themes/src/g100.js
+++ b/packages/themes/src/g100.js
@@ -23,7 +23,7 @@ import {
   gray100,
 
   // Support
-  green50,
+  green40,
   yellow,
   red50,
   red80,
@@ -64,7 +64,7 @@ export const inverse01 = gray100;
 export const inverse02 = gray10;
 
 export const support01 = red50;
-export const support02 = green50;
+export const support02 = green40;
 export const support03 = yellow;
 export const support04 = blue50;
 

--- a/packages/themes/src/g90.js
+++ b/packages/themes/src/g90.js
@@ -24,7 +24,7 @@ import {
   gray100,
 
   // Support
-  green50,
+  green40,
   yellow,
   red50,
   red80,
@@ -65,7 +65,7 @@ export const inverse01 = gray100;
 export const inverse02 = gray10;
 
 export const support01 = red50;
-export const support02 = green50;
+export const support02 = green40;
 export const support03 = yellow;
 export const support04 = blue50;
 


### PR DESCRIPTION
PR based on @shixiedesign's comment here: https://github.com/IBM/carbon-components/issues/1731#issuecomment-461562980

> Change token `$support-02` ’s values to Green 50 / `#24A148` on both light themes, and Green 40 / `#3DBB61` on both dark themes.

#### Changelog

**Changed**

- change `$support-02` to green40 for g90 and g100 themes
