### PR TITLE
add interactive-04 and link-01

### DIFF
--- a/packages/themes/src/g10.js
+++ b/packages/themes/src/g10.js
@@ -8,6 +8,7 @@
 import {
   // Blue
   blue20,
+  blue50,
   blue60,
   blue70,
   blue80,
@@ -39,6 +40,7 @@ import {
 export const interactive01 = blue60;
 export const interactive02 = gray100;
 export const interactive03 = blue60;
+export const interactive04 = blue60;
 
 export const uiBackground = gray10;
 
@@ -56,6 +58,8 @@ export const text04 = white;
 export const icon01 = gray100;
 export const icon02 = gray70;
 export const icon03 = white;
+
+export const link01 = blue60;
 
 export const field01 = white;
 export const field02 = gray10;

--- a/packages/themes/src/g10.js
+++ b/packages/themes/src/g10.js
@@ -8,7 +8,6 @@
 import {
   // Blue
   blue20,
-  blue50,
   blue60,
   blue70,
   blue80,

--- a/packages/themes/src/g100.js
+++ b/packages/themes/src/g100.js
@@ -7,6 +7,7 @@
 
 import {
   // Blue
+  blue40,
   blue50,
   blue60,
   blue70,
@@ -39,6 +40,7 @@ import {
 export const interactive01 = blue60;
 export const interactive02 = gray60;
 export const interactive03 = white;
+export const interactive04 = blue50;
 
 export const uiBackground = gray100;
 
@@ -56,6 +58,8 @@ export const text04 = white;
 export const icon01 = gray10;
 export const icon02 = gray30;
 export const icon03 = white;
+
+export const link01 = blue40;
 
 export const field01 = gray90;
 export const field02 = gray80;

--- a/packages/themes/src/g90.js
+++ b/packages/themes/src/g90.js
@@ -7,6 +7,7 @@
 
 import {
   // Blue
+  blue40,
   blue50,
   blue60,
   blue70,
@@ -40,6 +41,7 @@ import {
 export const interactive01 = blue60;
 export const interactive02 = gray60;
 export const interactive03 = white;
+export const interactive04 = blue50;
 
 export const uiBackground = gray90;
 
@@ -57,6 +59,8 @@ export const text04 = white;
 export const icon01 = gray10;
 export const icon02 = gray30;
 export const icon03 = white;
+
+export const link01 = blue40;
 
 export const field01 = gray80;
 export const field02 = gray70;

--- a/packages/themes/src/white.js
+++ b/packages/themes/src/white.js
@@ -8,6 +8,7 @@
 import {
   // Blue
   blue20,
+  blue50,
   blue60,
   blue70,
   blue80,
@@ -39,6 +40,7 @@ import {
 export const interactive01 = blue60;
 export const interactive02 = gray100;
 export const interactive03 = blue60;
+export const interactive04 = blue60;
 
 export const uiBackground = white;
 
@@ -56,6 +58,8 @@ export const text04 = white;
 export const icon01 = gray100;
 export const icon02 = gray70;
 export const icon03 = white;
+
+export const link01 = blue60;
 
 export const field01 = gray10;
 export const field02 = white;

--- a/packages/themes/src/white.js
+++ b/packages/themes/src/white.js
@@ -8,7 +8,6 @@
 import {
   // Blue
   blue20,
-  blue50,
   blue60,
   blue70,
   blue80,


### PR DESCRIPTION
Closes https://github.com/IBM/carbon-elements/issues/366
Adding two additional tokens so Tabs and links get the accessible blues: `$interactive-04`, `$link-01`

Related: https://github.com/IBM/carbon-components/issues/1757 