### PR TITLE
feat(icons): support hidden paths and preserve ids

### DIFF
--- a/packages/icons/src/svgo.js
+++ b/packages/icons/src/svgo.js
@@ -107,22 +107,6 @@ const plugins = [
     removeHiddenElems: {
       // Special case where we don't want to ignore nodes with `opacity="0"`
       opacity0: false,
-
-      // Default options
-      isHidden: true,
-      displayNone: true,
-      circleR0: true,
-      ellipseRX0: true,
-      ellipseRY0: true,
-      rectWidth0: true,
-      rectHeight0: true,
-      patternWidth0: true,
-      patternHeight0: true,
-      imageWidth0: true,
-      imageHeight0: true,
-      pathEmptyD: true,
-      polylineEmptyPoints: true,
-      polygonEmptyPoints: true,
     },
   },
   {

--- a/packages/icons/src/svgo.js
+++ b/packages/icons/src/svgo.js
@@ -147,7 +147,7 @@ const plugins = [
   },
   {
     cleanupIDs: {
-      preserve: [],
+      preserve: ['inner-path'],
     },
   },
   {

--- a/packages/icons/src/svgo.js
+++ b/packages/icons/src/svgo.js
@@ -37,12 +37,15 @@ const plugins = [
         if (item.isElem('g') && item.attr('id', 'Transparent_Rectangle')) {
           return item.content;
         }
+
         if (item.hasAttr('id')) {
           if (item.attr('id').value.includes('Transparent_Rectangle')) {
             return !item;
           }
         }
+
         const sizes = ['16', '20', '24', '32'];
+
         for (const size of sizes) {
           if (
             item.isElem('rect') &&


### PR DESCRIPTION
Support hidden paths (`opacity="0"`) and add option to preserve ids in `cleanupIDs` pass.

#### Changelog

**New**

**Changed**

- `icons`
  - Update SVGO plugins

**Removed**
