### PR TITLE
 docs(migrate): add layout docs

### DIFF
--- a/docs/guides/verifying-icons.md
+++ b/docs/guides/verifying-icons.md
@@ -1,13 +1,14 @@
+# Verifying icons
+
+<!-- prettier-ignore-start -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-
 ## Table of Contents
 
-- [Verifying icons](#verifying-icons) - [Common issues](#common-issues)
+- [Common issues](#common-issues)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
-# Verifying icons
+<!-- prettier-ignore-end -->
 
 Steps:
 

--- a/docs/migration/10.x-grid.md
+++ b/docs/migration/10.x-grid.md
@@ -1,0 +1,118 @@
+# Grid
+
+<!-- prettier-ignore-start -->
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+## Table of Contents
+
+- [About](#about)
+- [Migrating](#migrating)
+  - [Breakpoints](#breakpoints)
+  - [Columns](#columns)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+<!-- prettier-ignore-end -->
+
+## About
+
+The minimal grid that was shipped in previous versions of Carbon Components has
+now been extracted out into its own packages: `@carbon/grid` and
+`@carbon/layout`. Both of these packages are included by default in
+`@carbon/elements`. They are also integrated into `carbon-components` directly
+so there is no need to install additional packages if you are using
+`carbon-components` already.
+
+## Migrating
+
+To include the grid work in `carbon-components`, one would either include the
+default `styles.scss` entrypoint or include the grid directly. These imports
+are approximately:
+
+```scss
+// Global style import
+@import 'carbon-components/scss/globals/scss/styles.scss';
+
+// Grid-specific import
+@import 'carbon-components/scss/globals/grid/grid';
+```
+
+In v10 of Carbon, both of these imports will still work. However, there are some
+small differences that you will need to make in order for your grid code to
+function properly. Below is a table of the grid-specific variables, functions,
+and mixins in order to reference their status in Carbon v10.
+
+| v9                         | v10                                                 |
+| -------------------------- | --------------------------------------------------- |
+| `$max-width`               | Deprecated, access from `$carbon--grid-breakpoints` |
+| `$columns`                 | Deprecated, access from `$carbon--grid-breakpoints` |
+| `$grid-breakpoints`        | Replaced with `$carbon--grid-breakpoints`           |
+| `$gutter-breakpoints`      | Deprecated                                          |
+| `$grid-gutter-breakpoints` | Deprecated                                          |
+| `grid` mixin               | Use `carbon--grid` mixin from `@carbon/grid`        |
+| `breakpoint` function      | Replaced with `carbon--breakpoint`                  |
+| `gutter` function          | Deprecated                                          |
+| `grid-gutter` function     | Deprecated                                          |
+| `column-size` mixin        | Replaced with `carbon--make-col`                    |
+
+### Breakpoints
+
+The main difference between the v10 version of the grid and earlier versions
+will be the breakpoint names. Below is a table showing how they translate into
+the new version of the grid:
+
+| v9  | v10     |
+| --- | ------- |
+| xs  | sm      |
+| sm  | md      |
+| md  | lg      |
+| lg  | xlg     |
+| xl  | max     |
+| xxl | Removed |
+
+These most likely are being used in your column-specific class names. For
+example, the following code snippet contains the `xs` breakpoint:
+
+```html
+<div class="bx--col-xs-2"><!-- Content --></div>
+```
+
+In the latest version of the grid, the `xs` breakpoint corresponds to the `sm`
+breakpoint when referencing the table above. To update this column, you would
+need to write the following:
+
+```html
+<div class="bx--col-sm-2"><!-- Content --></div>
+```
+
+For a complete class reference, see the table below:
+
+| v9                               | v10                                              |
+| -------------------------------- | ------------------------------------------------ |
+| `bx--grid`                       | No change                                        |
+| `bx--row`                        | No change                                        |
+| `bx--col-<breakpoint>-<span>`    | Minimal change, replace breakpoint with new name |
+| `bx--offset-<breakpoint>-<span>` | Minimal change, replace breakpoint with new name |
+
+### Columns
+
+The default column count in previous versions of the Carbon Design System was
+set to 12. In v10, the default column count is still 12. However, the updated
+IBM Design Language specifies that layouts should now begin transitioning to a
+16 column grid. As a result, we offer a feature flag called `grid-columns-16`
+that you can use to enable 16 columns in your grid.
+
+_Note: if using `@carbon/grid` or `@carbon/elements` directly, you will **not**
+need to do this_
+
+To enable this in your project, you can specify this feature flag by writing the
+following Sass code before importing the grid from `carbon-components`:
+
+```scss
+$feature-flags: (
+  grid-columns-16: true,
+);
+
+// Use one of the following two options to then import the grid code:
+// 1) @import 'carbon-components/scss/globals/scss/styles.scss';
+// 2) @import 'carbon-components/scss/globals/grid/grid';
+```

--- a/docs/migration/10.x-grid.md
+++ b/docs/migration/10.x-grid.md
@@ -18,9 +18,10 @@
 The minimal grid that was shipped in previous versions of Carbon Components has
 now been extracted out into its own packages: `@carbon/grid` and
 `@carbon/layout`. Both of these packages are included by default in
-`@carbon/elements`. They are also integrated into `carbon-components` directly
-so there is no need to install additional packages if you are using
-`carbon-components` already.
+`@carbon/elements`.
+
+They are also integrated into `carbon-components` directly so there is no need to
+install additional packages if you are using `carbon-components` already.
 
 ## Migrating
 

--- a/docs/migration/10.x-layout.md
+++ b/docs/migration/10.x-layout.md
@@ -1,0 +1,62 @@
+# Layout
+
+<!-- prettier-ignore-start -->
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+## Table of Contents
+
+- [About](#about)
+- [Migrating](#migrating)
+  - [Breakpoints](#breakpoints)
+  - [Columns](#columns)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+<!-- prettier-ignore-end -->
+
+## About
+
+Layout-related code, including conversion, spacing, and breakpoints, have been
+moved over into their own package: `@carbon/layout`. This package is also
+included by default in `@carbon/elements`.
+
+They are also integrated into `carbon-components` directly so there is no need to
+install additional packages if you are using `carbon-components` already.
+
+## Migrating
+
+| v9                  | v10                                         |
+| ------------------- | ------------------------------------------- |
+| `$base-font-size`   | `$carbon--base-font-size`                   |
+| `rem`, `em` helpers | `carbon--rem`,`carbon--em`                  |
+| `$grid-breakpoints` |                                             |
+|                     | `carbon--breakpoint-next`                   |
+|                     | `carbon--breakpoint-prev`                   |
+|                     | `carbon--breakpoint-is-smallest-breakpoint` |
+|                     | `carbon--largest-breakpoint-name`           |
+|                     | `carbon--breakpoint-up`                     |
+|                     | `carbon--breakpoint-down`                   |
+|                     | `carbon--breakpoint-between`                |
+|                     | Mixin `carbon--breakpoint`                  |
+|                     | `carbon--largest-breakpoint`                |
+|                     | `$carbon--grid-gutter`                      |
+|                     | `$carbon--grid-gutter--condensed`           |
+|                     | `carbon--key-height`                        |
+|                     | Mixin `carbon--key-height`                  |
+|                     | `$carbon--mini-unit-size`                   |
+|                     | function `carbon--mini-units`               |
+| `$spacing-3xs`      | `$carbon--spacing-01`, `$spacing-01`        |
+| `$spacing-2xs`      | `$carbon--spacing-02`, `$spacing-02`        |
+| `$spacing-xs`       | `$carbon--spacing-03`, `$spacing-03`        |
+| `$spacing-sm`       | `$carbon--spacing-04`, `$spacing-04`        |
+| `$spacing-md`       | `$carbon--spacing-05`, `$spacing-05`        |
+| `$spacing-lg`       | `$carbon--spacing-06`, `$spacing-06`        |
+| `$spacing-xl`       | `$carbon--spacing-07`, `$spacing-07`        |
+| `$spacing-2xl`      | `$carbon--spacing-08`, `$spacing-08`        |
+| `$spacing-3xl`      | `$carbon--spacing-09`, `$spacing-09`        |
+| `$layout-2xs`       | `$carbon--layout-01`, `$layout-01`          |
+| `$layout-xs`        | `$carbon--layout-02`, `$layout-02`          |
+| `$layout-sm`        | `$carbon--layout-03`, `$layout-03`          |
+| `$layout-md`        | `$carbon--layout-04`, `$layout-04`          |
+| `$layout-lg`        | `$carbon--layout-05`, `$layout-05`          |
+| `$layout-xl`        | `$carbon--layout-06`, `$layout-06`          |
+| `$layout-2xl`       | `$carbon--layout-07`, `$layout-07`          |

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,16 +1,16 @@
+# Publishing
+
+<!-- prettier-ignore-start -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-
 ## Table of Contents
 
-- [Publishing](#publishing)
-  - [Pre-release](#pre-release)
-  - [FAQ](#faq)
+- [Pre-release](#pre-release)
+- [FAQ](#faq)
     - [How do I fix the repo state if I cancel during a publish?](#how-do-i-fix-the-repo-state-if-i-cancel-during-a-publish)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
-# Publishing
+<!-- prettier-ignore-end -->
 
 > Steps for publishing the monorepo
 

--- a/docs/technical-preview.md
+++ b/docs/technical-preview.md
@@ -1,18 +1,18 @@
+# Carbon Elements Technical Preview
+
+<!-- prettier-ignore-start -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-
 ## Table of Contents
 
-- [Carbon Elements Technical Preview](#carbon-elements-technical-preview)
-  - [Why Carbon Elements](#why-carbon-elements)
-  - [What to expect](#what-to-expect)
-  - [Feedback](#feedback)
-  - [What's next](#whats-next)
-  - [Contributing](#contributing)
+- [Why Carbon Elements](#why-carbon-elements)
+- [What to expect](#what-to-expect)
+- [Feedback](#feedback)
+- [What's next](#whats-next)
+- [Contributing](#contributing)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
-# Carbon Elements Technical Preview
+<!-- prettier-ignore-end -->
 
 Today, we're excited to introduce a new project to the Carbon Design System called Carbon Elements! <span aria-label="celebrate" role="img">🎉</span>
 


### PR DESCRIPTION
Closes #271 

Add migration guides for grid and layout.

#### Changelog

**New**

- Add migration guides for grid and layout

**Changed**

**Removed**
