### PR TITLE
icon update

### DIFF
--- a/packages/icons/src/svg/16/warning--filled.svg
+++ b/packages/icons/src/svg/16/warning--filled.svg
@@ -1,16 +1,1 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 23.0.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="16px" height="16px" viewBox="0 0 16 16" style="enable-background:new 0 0 16 16;" xml:space="preserve">
-<style type="text/css">
-	.st0{fill:none;}
-	.st1{opacity:0;fill:#FFFFFF;}
-</style>
-<rect class="st0" width="16" height="16"/>
-<g>
-	<path d="M8,1C4.1,1,1,4.1,1,8s3.1,7,7,7s7-3.1,7-7S11.9,1,8,1z M8,12.5c-0.4,0-1-0.5-1-1s0.5-1,1-1s1,0.5,1,1S8.5,12.5,8,12.5z
-		 M9,5.6V9H7V5.6V4h2V5.6z"/>
-	<path id="inner-path" class="st1" d="M7,11.5c0-0.5,0.5-1,1-1s1,0.5,1,1s-0.5,1-1,1C7.6,12.5,7,12,7,11.5z M7,9V5.6V4h2v1.6V9H7z"
-		/>
-</g>
-</svg>
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><defs><style>.cls-1{fill:#fff;opacity:0;}.cls-2{fill:none;}</style></defs><title>warning--filled</title><path id="Compound_Path" data-name="Compound Path" d="M8,1a7,7,0,1,0,7,7A7.0078,7.0078,0,0,0,8,1ZM7.4375,4h1.125V9H7.4375ZM8,11.8a.736.736,0,0,1-.8-.8.8.8,0,1,1,.8.8Z"/><path id="inner-path" class="cls-1" d="M8.8,11a.7887.7887,0,0,1-.8.8.736.736,0,0,1-.8-.8.8.8,0,0,1,1.6,0ZM8.5625,4H7.4375V9h1.125Z"/><rect id="Transparent_Rectangle" data-name="Transparent Rectangle" class="cls-2" width="16" height="16"/></svg>


### PR DESCRIPTION
Replaced 16x16px `warning--filled.svg` with one with correct styling. 

A few issues with the old icon called for this update: 

1. In notification, the warning icon looks wrong because it's style is too chubby compared to the rest. Many thought it was a mistake, including Lauren. 
![image](https://user-images.githubusercontent.com/15144993/54240575-735dab80-44ec-11e9-8c01-702ebede0e56.png)

2. The filled and unfilled icon are inconsistent. The only difference between these two icons should be the fill. Not stroke width.
![image](https://user-images.githubusercontent.com/15144993/54240602-87a1a880-44ec-11e9-8221-c5bfc6a2eb29.png)


