### PR TITLE
chore(lint): running StyleLint only for staged files

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "format:staged": "prettier --write",
     "lint": "toolkit lint .",
     "lint:styles": "stylelint \"**/*.{css,scss}\" --config ./packages/stylelint-config-elements",
-    "lint:styles:staged": "stylelint --config ./packages/stylelint-config-elements",
     "sync": "node tasks/sync.js",
     "test": "jest",
     "test:e2e": "jest --testPathPattern=e2e --testPathIgnorePatterns=examples"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "format:staged": "prettier --write",
     "lint": "toolkit lint .",
     "lint:styles": "stylelint \"**/*.{css,scss}\" --config ./packages/stylelint-config-elements",
+    "lint:styles:staged": "stylelint --config ./packages/stylelint-config-elements",
     "sync": "node tasks/sync.js",
     "test": "jest",
     "test:e2e": "jest --testPathPattern=e2e --testPathIgnorePatterns=examples"
@@ -87,7 +88,7 @@
     ],
     "*.{scss,css}": [
       "yarn format:staged",
-      "yarn lint:styles",
+      "yarn lint:styles:staged",
       "git add"
     ],
     "*.md": [

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     ],
     "*.{scss,css}": [
       "yarn format:staged",
-      "yarn lint:styles:staged",
+      "stylelint --config ./packages/stylelint-config-elements",
       "git add"
     ],
     "*.md": [


### PR DESCRIPTION
#### Changelog

**Changed**

- A change to run StyleLint only for staged files when it runs upon commit. In old code, it ran against all CSS/Sass files in the project.