### PR TITLE
chore: update fonts to latest version and add greek support for sans

### DIFF
--- a/packages/type/examples/preview/styles.scss
+++ b/packages/type/examples/preview/styles.scss
@@ -7,6 +7,10 @@
 @include carbon--type-reset();
 @include carbon--type-classes();
 
+@include carbon--font-face-sans();
+@include carbon--font-face-serif();
+@include carbon--font-face-mono();
+
 //------------------------------------------------------------------------------
 // Font-face
 //------------------------------------------------------------------------------

--- a/packages/type/scss/font-face/_sans.scss
+++ b/packages/type/scss/font-face/_sans.scss
@@ -12,7 +12,7 @@
     font-style: italic;
     font-weight: 300;
     src: local('IBM Plex Sans Light Italic'), local('IBMPlexSans-LightItalic'),
-      url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX7KVElMYYaJe8bpLHnCwDKhdTmvIRcdvfo.woff)
+      url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX7KVElMYYaJe8bpLHnCwDKhdTmvIRcdvfo.woff)
         format('woff');
   }
   @font-face {
@@ -20,7 +20,7 @@
     font-style: italic;
     font-weight: 400;
     src: local('IBM Plex Sans Italic'), local('IBMPlexSans-Italic'),
-      url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX-KVElMYYaJe8bpLHnCwDKhdTuF6ZP.woff)
+      url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX-KVElMYYaJe8bpLHnCwDKhdTuF6ZP.woff)
         format('woff');
   }
   @font-face {
@@ -29,7 +29,7 @@
     font-weight: 600;
     src: local('IBM Plex Sans SemiBold Italic'),
       local('IBMPlexSans-SemiBoldItalic'),
-      url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX7KVElMYYaJe8bpLHnCwDKhdTmyIJcdvfo.woff)
+      url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX7KVElMYYaJe8bpLHnCwDKhdTmyIJcdvfo.woff)
         format('woff');
   }
   @font-face {
@@ -37,7 +37,7 @@
     font-style: normal;
     font-weight: 300;
     src: local('IBM Plex Sans Light'), local('IBMPlexSans-Light'),
-      url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX9KVElMYYaJe8bpLHnCwDKjXr8AIFscg.woff)
+      url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjXr8AIFscg.woff)
         format('woff');
   }
   @font-face {
@@ -45,7 +45,7 @@
     font-style: normal;
     font-weight: 400;
     src: local('IBM Plex Sans'), local('IBMPlexSans'),
-      url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYXgKVElMYYaJe8bpLHnCwDKhdHeEw.woff)
+      url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYXgKVElMYYaJe8bpLHnCwDKhdHeEw.woff)
         format('woff');
   }
   @font-face {
@@ -53,7 +53,7 @@
     font-style: normal;
     font-weight: 600;
     src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'),
-      url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIFscg.woff)
+      url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIFscg.woff)
         format('woff');
   }
 
@@ -63,7 +63,7 @@
     font-style: italic;
     font-weight: 300;
     src: local('IBM Plex Sans Light Italic'), local('IBMPlexSans-LightItalic'),
-      url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX7KVElMYYaJe8bpLHnCwDKhdTmvIRce_fuJGl18QRY.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX7KVElMYYaJe8bpLHnCwDKhdTmvIRce_fuJGl18QRY.woff2)
         format('woff2');
     unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F,
       U+FE2E-FE2F;
@@ -74,9 +74,19 @@
     font-style: italic;
     font-weight: 300;
     src: local('IBM Plex Sans Light Italic'), local('IBMPlexSans-LightItalic'),
-      url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX7KVElMYYaJe8bpLHnCwDKhdTmvIRccvfuJGl18QRY.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX7KVElMYYaJe8bpLHnCwDKhdTmvIRccvfuJGl18QRY.woff2)
         format('woff2');
     unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+  }
+  /* greek */
+  @font-face {
+    font-family: 'IBM Plex Sans';
+    font-style: italic;
+    font-weight: 300;
+    src: local('IBM Plex Sans Light Italic'), local('IBMPlexSans-LightItalic'),
+      url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX7KVElMYYaJe8bpLHnCwDKhdTmvIRcdffuJGl18QRY.woff2)
+        format('woff2');
+    unicode-range: U+0370-03FF;
   }
   /* vietnamese */
   @font-face {
@@ -84,7 +94,7 @@
     font-style: italic;
     font-weight: 300;
     src: local('IBM Plex Sans Light Italic'), local('IBMPlexSans-LightItalic'),
-      url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX7KVElMYYaJe8bpLHnCwDKhdTmvIRceffuJGl18QRY.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX7KVElMYYaJe8bpLHnCwDKhdTmvIRceffuJGl18QRY.woff2)
         format('woff2');
     unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB;
   }
@@ -94,7 +104,7 @@
     font-style: italic;
     font-weight: 300;
     src: local('IBM Plex Sans Light Italic'), local('IBMPlexSans-LightItalic'),
-      url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX7KVElMYYaJe8bpLHnCwDKhdTmvIRcePfuJGl18QRY.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX7KVElMYYaJe8bpLHnCwDKhdTmvIRcePfuJGl18QRY.woff2)
         format('woff2');
     unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB,
       U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
@@ -105,7 +115,7 @@
     font-style: italic;
     font-weight: 300;
     src: local('IBM Plex Sans Light Italic'), local('IBMPlexSans-LightItalic'),
-      url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX7KVElMYYaJe8bpLHnCwDKhdTmvIRcdvfuJGl18Q.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX7KVElMYYaJe8bpLHnCwDKhdTmvIRcdvfuJGl18Q.woff2)
         format('woff2');
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
       U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212,
@@ -117,7 +127,7 @@
     font-style: italic;
     font-weight: 400;
     src: local('IBM Plex Sans Italic'), local('IBMPlexSans-Italic'),
-      url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX-KVElMYYaJe8bpLHnCwDKhdTuGqZJW9XjDlN8.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX-KVElMYYaJe8bpLHnCwDKhdTuGqZJW9XjDlN8.woff2)
         format('woff2');
     unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F,
       U+FE2E-FE2F;
@@ -128,9 +138,19 @@
     font-style: italic;
     font-weight: 400;
     src: local('IBM Plex Sans Italic'), local('IBMPlexSans-Italic'),
-      url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX-KVElMYYaJe8bpLHnCwDKhdTuE6ZJW9XjDlN8.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX-KVElMYYaJe8bpLHnCwDKhdTuE6ZJW9XjDlN8.woff2)
         format('woff2');
     unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+  }
+  /* greek */
+  @font-face {
+    font-family: 'IBM Plex Sans';
+    font-style: italic;
+    font-weight: 400;
+    src: local('IBM Plex Sans Italic'), local('IBMPlexSans-Italic'),
+      url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX-KVElMYYaJe8bpLHnCwDKhdTuFKZJW9XjDlN8.woff2)
+        format('woff2');
+    unicode-range: U+0370-03FF;
   }
   /* vietnamese */
   @font-face {
@@ -138,7 +158,7 @@
     font-style: italic;
     font-weight: 400;
     src: local('IBM Plex Sans Italic'), local('IBMPlexSans-Italic'),
-      url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX-KVElMYYaJe8bpLHnCwDKhdTuGKZJW9XjDlN8.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX-KVElMYYaJe8bpLHnCwDKhdTuGKZJW9XjDlN8.woff2)
         format('woff2');
     unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB;
   }
@@ -148,7 +168,7 @@
     font-style: italic;
     font-weight: 400;
     src: local('IBM Plex Sans Italic'), local('IBMPlexSans-Italic'),
-      url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX-KVElMYYaJe8bpLHnCwDKhdTuGaZJW9XjDlN8.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX-KVElMYYaJe8bpLHnCwDKhdTuGaZJW9XjDlN8.woff2)
         format('woff2');
     unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB,
       U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
@@ -159,7 +179,7 @@
     font-style: italic;
     font-weight: 400;
     src: local('IBM Plex Sans Italic'), local('IBMPlexSans-Italic'),
-      url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX-KVElMYYaJe8bpLHnCwDKhdTuF6ZJW9XjDg.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX-KVElMYYaJe8bpLHnCwDKhdTuF6ZJW9XjDg.woff2)
         format('woff2');
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
       U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212,
@@ -172,7 +192,7 @@
     font-weight: 600;
     src: local('IBM Plex Sans SemiBold Italic'),
       local('IBMPlexSans-SemiBoldItalic'),
-      url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX7KVElMYYaJe8bpLHnCwDKhdTmyIJce_fuJGl18QRY.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX7KVElMYYaJe8bpLHnCwDKhdTmyIJce_fuJGl18QRY.woff2)
         format('woff2');
     unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F,
       U+FE2E-FE2F;
@@ -184,9 +204,20 @@
     font-weight: 600;
     src: local('IBM Plex Sans SemiBold Italic'),
       local('IBMPlexSans-SemiBoldItalic'),
-      url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX7KVElMYYaJe8bpLHnCwDKhdTmyIJccvfuJGl18QRY.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX7KVElMYYaJe8bpLHnCwDKhdTmyIJccvfuJGl18QRY.woff2)
         format('woff2');
     unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+  }
+  /* greek */
+  @font-face {
+    font-family: 'IBM Plex Sans';
+    font-style: italic;
+    font-weight: 600;
+    src: local('IBM Plex Sans SemiBold Italic'),
+      local('IBMPlexSans-SemiBoldItalic'),
+      url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX7KVElMYYaJe8bpLHnCwDKhdTmyIJcdffuJGl18QRY.woff2)
+        format('woff2');
+    unicode-range: U+0370-03FF;
   }
   /* vietnamese */
   @font-face {
@@ -195,7 +226,7 @@
     font-weight: 600;
     src: local('IBM Plex Sans SemiBold Italic'),
       local('IBMPlexSans-SemiBoldItalic'),
-      url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX7KVElMYYaJe8bpLHnCwDKhdTmyIJceffuJGl18QRY.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX7KVElMYYaJe8bpLHnCwDKhdTmyIJceffuJGl18QRY.woff2)
         format('woff2');
     unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB;
   }
@@ -206,7 +237,7 @@
     font-weight: 600;
     src: local('IBM Plex Sans SemiBold Italic'),
       local('IBMPlexSans-SemiBoldItalic'),
-      url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX7KVElMYYaJe8bpLHnCwDKhdTmyIJcePfuJGl18QRY.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX7KVElMYYaJe8bpLHnCwDKhdTmyIJcePfuJGl18QRY.woff2)
         format('woff2');
     unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB,
       U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
@@ -218,7 +249,7 @@
     font-weight: 600;
     src: local('IBM Plex Sans SemiBold Italic'),
       local('IBMPlexSans-SemiBoldItalic'),
-      url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX7KVElMYYaJe8bpLHnCwDKhdTmyIJcdvfuJGl18Q.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX7KVElMYYaJe8bpLHnCwDKhdTmyIJcdvfuJGl18Q.woff2)
         format('woff2');
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
       U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212,
@@ -230,7 +261,7 @@
     font-style: normal;
     font-weight: 300;
     src: local('IBM Plex Sans Light'), local('IBMPlexSans-Light'),
-      url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX9KVElMYYaJe8bpLHnCwDKjXr8AIxsdP3pBmtF8A.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjXr8AIxsdP3pBmtF8A.woff2)
         format('woff2');
     unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F,
       U+FE2E-FE2F;
@@ -241,9 +272,19 @@
     font-style: normal;
     font-weight: 300;
     src: local('IBM Plex Sans Light'), local('IBMPlexSans-Light'),
-      url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX9KVElMYYaJe8bpLHnCwDKjXr8AIVsdP3pBmtF8A.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjXr8AIVsdP3pBmtF8A.woff2)
         format('woff2');
     unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+  }
+  /* greek */
+  @font-face {
+    font-family: 'IBM Plex Sans';
+    font-style: normal;
+    font-weight: 300;
+    src: local('IBM Plex Sans Light'), local('IBMPlexSans-Light'),
+      url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjXr8AIJsdP3pBmtF8A.woff2)
+        format('woff2');
+    unicode-range: U+0370-03FF;
   }
   /* vietnamese */
   @font-face {
@@ -251,7 +292,7 @@
     font-style: normal;
     font-weight: 300;
     src: local('IBM Plex Sans Light'), local('IBMPlexSans-Light'),
-      url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX9KVElMYYaJe8bpLHnCwDKjXr8AI5sdP3pBmtF8A.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjXr8AI5sdP3pBmtF8A.woff2)
         format('woff2');
     unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB;
   }
@@ -261,7 +302,7 @@
     font-style: normal;
     font-weight: 300;
     src: local('IBM Plex Sans Light'), local('IBMPlexSans-Light'),
-      url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX9KVElMYYaJe8bpLHnCwDKjXr8AI9sdP3pBmtF8A.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjXr8AI9sdP3pBmtF8A.woff2)
         format('woff2');
     unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB,
       U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
@@ -272,7 +313,7 @@
     font-style: normal;
     font-weight: 300;
     src: local('IBM Plex Sans Light'), local('IBMPlexSans-Light'),
-      url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX9KVElMYYaJe8bpLHnCwDKjXr8AIFsdP3pBms.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjXr8AIFsdP3pBms.woff2)
         format('woff2');
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
       U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212,
@@ -284,7 +325,7 @@
     font-style: normal;
     font-weight: 400;
     src: local('IBM Plex Sans'), local('IBMPlexSans'),
-      url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYXgKVElMYYaJe8bpLHnCwDKhdzeFaxOedfTDw.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYXgKVElMYYaJe8bpLHnCwDKhdzeFaxOedfTDw.woff2)
         format('woff2');
     unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F,
       U+FE2E-FE2F;
@@ -295,9 +336,19 @@
     font-style: normal;
     font-weight: 400;
     src: local('IBM Plex Sans'), local('IBMPlexSans'),
-      url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYXgKVElMYYaJe8bpLHnCwDKhdXeFaxOedfTDw.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYXgKVElMYYaJe8bpLHnCwDKhdXeFaxOedfTDw.woff2)
         format('woff2');
     unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+  }
+  /* greek */
+  @font-face {
+    font-family: 'IBM Plex Sans';
+    font-style: normal;
+    font-weight: 400;
+    src: local('IBM Plex Sans'), local('IBMPlexSans'),
+      url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYXgKVElMYYaJe8bpLHnCwDKhdLeFaxOedfTDw.woff2)
+        format('woff2');
+    unicode-range: U+0370-03FF;
   }
   /* vietnamese */
   @font-face {
@@ -305,7 +356,7 @@
     font-style: normal;
     font-weight: 400;
     src: local('IBM Plex Sans'), local('IBMPlexSans'),
-      url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYXgKVElMYYaJe8bpLHnCwDKhd7eFaxOedfTDw.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYXgKVElMYYaJe8bpLHnCwDKhd7eFaxOedfTDw.woff2)
         format('woff2');
     unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB;
   }
@@ -315,7 +366,7 @@
     font-style: normal;
     font-weight: 400;
     src: local('IBM Plex Sans'), local('IBMPlexSans'),
-      url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYXgKVElMYYaJe8bpLHnCwDKhd_eFaxOedfTDw.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYXgKVElMYYaJe8bpLHnCwDKhd_eFaxOedfTDw.woff2)
         format('woff2');
     unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB,
       U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
@@ -326,7 +377,7 @@
     font-style: normal;
     font-weight: 400;
     src: local('IBM Plex Sans'), local('IBMPlexSans'),
-      url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYXgKVElMYYaJe8bpLHnCwDKhdHeFaxOedc.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYXgKVElMYYaJe8bpLHnCwDKhdHeFaxOedc.woff2)
         format('woff2');
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
       U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212,
@@ -338,7 +389,7 @@
     font-style: normal;
     font-weight: 600;
     src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'),
-      url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIxsdP3pBmtF8A.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIxsdP3pBmtF8A.woff2)
         format('woff2');
     unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F,
       U+FE2E-FE2F;
@@ -349,9 +400,19 @@
     font-style: normal;
     font-weight: 600;
     src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'),
-      url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIVsdP3pBmtF8A.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIVsdP3pBmtF8A.woff2)
         format('woff2');
     unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+  }
+  /* greek */
+  @font-face {
+    font-family: 'IBM Plex Sans';
+    font-style: normal;
+    font-weight: 600;
+    src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'),
+      url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIJsdP3pBmtF8A.woff2)
+        format('woff2');
+    unicode-range: U+0370-03FF;
   }
   /* vietnamese */
   @font-face {
@@ -359,7 +420,7 @@
     font-style: normal;
     font-weight: 600;
     src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'),
-      url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX9KVElMYYaJe8bpLHnCwDKjQ76AI5sdP3pBmtF8A.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjQ76AI5sdP3pBmtF8A.woff2)
         format('woff2');
     unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB;
   }
@@ -369,7 +430,7 @@
     font-style: normal;
     font-weight: 600;
     src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'),
-      url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX9KVElMYYaJe8bpLHnCwDKjQ76AI9sdP3pBmtF8A.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjQ76AI9sdP3pBmtF8A.woff2)
         format('woff2');
     unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB,
       U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
@@ -380,7 +441,7 @@
     font-style: normal;
     font-weight: 600;
     src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'),
-      url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIFsdP3pBms.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIFsdP3pBms.woff2)
         format('woff2');
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
       U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212,

--- a/packages/type/scss/font-face/_serif.scss
+++ b/packages/type/scss/font-face/_serif.scss
@@ -12,7 +12,7 @@
     font-style: italic;
     font-weight: 300;
     src: local('IBM Plex Serif Light Italic'), local('IBMPlexSerif-LightItalic'),
-      url(https://fonts.gstatic.com/s/ibmplexserif/v5/jizGREVNn1dOx-zrZ2X3pZvkTiUa454xm1npiw.woff)
+      url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizGREVNn1dOx-zrZ2X3pZvkTiUa454xm1npiw.woff)
         format('woff');
   }
   @font-face {
@@ -20,7 +20,7 @@
     font-style: italic;
     font-weight: 400;
     src: local('IBM Plex Serif Italic'), local('IBMPlexSerif-Italic'),
-      url(https://fonts.gstatic.com/s/ibmplexserif/v5/jizBREVNn1dOx-zrZ2X3pZvkTiUa6zUTiA.woff)
+      url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizBREVNn1dOx-zrZ2X3pZvkTiUa6zUTiA.woff)
         format('woff');
   }
   @font-face {
@@ -29,7 +29,7 @@
     font-weight: 600;
     src: local('IBM Plex Serif SemiBold Italic'),
       local('IBMPlexSerif-SemiBoldItalic'),
-      url(https://fonts.gstatic.com/s/ibmplexserif/v5/jizGREVNn1dOx-zrZ2X3pZvkTiUa4-o3m1npiw.woff)
+      url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizGREVNn1dOx-zrZ2X3pZvkTiUa4-o3m1npiw.woff)
         format('woff');
   }
   @font-face {
@@ -37,7 +37,7 @@
     font-style: normal;
     font-weight: 300;
     src: local('IBM Plex Serif Light'), local('IBMPlexSerif-Light'),
-      url(https://fonts.gstatic.com/s/ibmplexserif/v5/jizAREVNn1dOx-zrZ2X3pZvkTi20-SI0q10.woff)
+      url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizAREVNn1dOx-zrZ2X3pZvkTi20-SI0q10.woff)
         format('woff');
   }
   @font-face {
@@ -45,7 +45,7 @@
     font-style: normal;
     font-weight: 400;
     src: local('IBM Plex Serif'), local('IBMPlexSerif'),
-      url(https://fonts.gstatic.com/s/ibmplexserif/v5/jizDREVNn1dOx-zrZ2X3pZvkTiUf2zE.woff)
+      url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizDREVNn1dOx-zrZ2X3pZvkTiUf2zE.woff)
         format('woff');
   }
   @font-face {
@@ -53,7 +53,7 @@
     font-style: normal;
     font-weight: 600;
     src: local('IBM Plex Serif SemiBold'), local('IBMPlexSerif-SemiBold'),
-      url(https://fonts.gstatic.com/s/ibmplexserif/v5/jizAREVNn1dOx-zrZ2X3pZvkTi3A_yI0q10.woff)
+      url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizAREVNn1dOx-zrZ2X3pZvkTi3A_yI0q10.woff)
         format('woff');
   }
 
@@ -63,7 +63,7 @@
     font-style: italic;
     font-weight: 300;
     src: local('IBM Plex Serif Light Italic'), local('IBMPlexSerif-LightItalic'),
-      url(https://fonts.gstatic.com/s/ibmplexserif/v5/jizGREVNn1dOx-zrZ2X3pZvkTiUa454xm1TpjfGj7oaMBg.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizGREVNn1dOx-zrZ2X3pZvkTiUa454xm1TpjfGj7oaMBg.woff2)
         format('woff2');
     unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F,
       U+FE2E-FE2F;
@@ -74,7 +74,7 @@
     font-style: italic;
     font-weight: 300;
     src: local('IBM Plex Serif Light Italic'), local('IBMPlexSerif-LightItalic'),
-      url(https://fonts.gstatic.com/s/ibmplexserif/v5/jizGREVNn1dOx-zrZ2X3pZvkTiUa454xm13pjfGj7oaMBg.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizGREVNn1dOx-zrZ2X3pZvkTiUa454xm13pjfGj7oaMBg.woff2)
         format('woff2');
     unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
   }
@@ -84,7 +84,7 @@
     font-style: italic;
     font-weight: 300;
     src: local('IBM Plex Serif Light Italic'), local('IBMPlexSerif-LightItalic'),
-      url(https://fonts.gstatic.com/s/ibmplexserif/v5/jizGREVNn1dOx-zrZ2X3pZvkTiUa454xm1bpjfGj7oaMBg.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizGREVNn1dOx-zrZ2X3pZvkTiUa454xm1bpjfGj7oaMBg.woff2)
         format('woff2');
     unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB;
   }
@@ -94,7 +94,7 @@
     font-style: italic;
     font-weight: 300;
     src: local('IBM Plex Serif Light Italic'), local('IBMPlexSerif-LightItalic'),
-      url(https://fonts.gstatic.com/s/ibmplexserif/v5/jizGREVNn1dOx-zrZ2X3pZvkTiUa454xm1fpjfGj7oaMBg.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizGREVNn1dOx-zrZ2X3pZvkTiUa454xm1fpjfGj7oaMBg.woff2)
         format('woff2');
     unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB,
       U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
@@ -105,7 +105,7 @@
     font-style: italic;
     font-weight: 300;
     src: local('IBM Plex Serif Light Italic'), local('IBMPlexSerif-LightItalic'),
-      url(https://fonts.gstatic.com/s/ibmplexserif/v5/jizGREVNn1dOx-zrZ2X3pZvkTiUa454xm1npjfGj7oY.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizGREVNn1dOx-zrZ2X3pZvkTiUa454xm1npjfGj7oY.woff2)
         format('woff2');
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
       U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212,
@@ -117,7 +117,7 @@
     font-style: italic;
     font-weight: 400;
     src: local('IBM Plex Serif Italic'), local('IBMPlexSerif-Italic'),
-      url(https://fonts.gstatic.com/s/ibmplexserif/v5/jizBREVNn1dOx-zrZ2X3pZvkTiUa6zgTjnTLgNuZ5w.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizBREVNn1dOx-zrZ2X3pZvkTiUa6zgTjnTLgNuZ5w.woff2)
         format('woff2');
     unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F,
       U+FE2E-FE2F;
@@ -128,7 +128,7 @@
     font-style: italic;
     font-weight: 400;
     src: local('IBM Plex Serif Italic'), local('IBMPlexSerif-Italic'),
-      url(https://fonts.gstatic.com/s/ibmplexserif/v5/jizBREVNn1dOx-zrZ2X3pZvkTiUa6zETjnTLgNuZ5w.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizBREVNn1dOx-zrZ2X3pZvkTiUa6zETjnTLgNuZ5w.woff2)
         format('woff2');
     unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
   }
@@ -138,7 +138,7 @@
     font-style: italic;
     font-weight: 400;
     src: local('IBM Plex Serif Italic'), local('IBMPlexSerif-Italic'),
-      url(https://fonts.gstatic.com/s/ibmplexserif/v5/jizBREVNn1dOx-zrZ2X3pZvkTiUa6zoTjnTLgNuZ5w.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizBREVNn1dOx-zrZ2X3pZvkTiUa6zoTjnTLgNuZ5w.woff2)
         format('woff2');
     unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB;
   }
@@ -148,7 +148,7 @@
     font-style: italic;
     font-weight: 400;
     src: local('IBM Plex Serif Italic'), local('IBMPlexSerif-Italic'),
-      url(https://fonts.gstatic.com/s/ibmplexserif/v5/jizBREVNn1dOx-zrZ2X3pZvkTiUa6zsTjnTLgNuZ5w.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizBREVNn1dOx-zrZ2X3pZvkTiUa6zsTjnTLgNuZ5w.woff2)
         format('woff2');
     unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB,
       U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
@@ -159,7 +159,7 @@
     font-style: italic;
     font-weight: 400;
     src: local('IBM Plex Serif Italic'), local('IBMPlexSerif-Italic'),
-      url(https://fonts.gstatic.com/s/ibmplexserif/v5/jizBREVNn1dOx-zrZ2X3pZvkTiUa6zUTjnTLgNs.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizBREVNn1dOx-zrZ2X3pZvkTiUa6zUTjnTLgNs.woff2)
         format('woff2');
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
       U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212,
@@ -172,7 +172,7 @@
     font-weight: 600;
     src: local('IBM Plex Serif SemiBold Italic'),
       local('IBMPlexSerif-SemiBoldItalic'),
-      url(https://fonts.gstatic.com/s/ibmplexserif/v5/jizGREVNn1dOx-zrZ2X3pZvkTiUa4-o3m1TpjfGj7oaMBg.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizGREVNn1dOx-zrZ2X3pZvkTiUa4-o3m1TpjfGj7oaMBg.woff2)
         format('woff2');
     unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F,
       U+FE2E-FE2F;
@@ -184,7 +184,7 @@
     font-weight: 600;
     src: local('IBM Plex Serif SemiBold Italic'),
       local('IBMPlexSerif-SemiBoldItalic'),
-      url(https://fonts.gstatic.com/s/ibmplexserif/v5/jizGREVNn1dOx-zrZ2X3pZvkTiUa4-o3m13pjfGj7oaMBg.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizGREVNn1dOx-zrZ2X3pZvkTiUa4-o3m13pjfGj7oaMBg.woff2)
         format('woff2');
     unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
   }
@@ -195,7 +195,7 @@
     font-weight: 600;
     src: local('IBM Plex Serif SemiBold Italic'),
       local('IBMPlexSerif-SemiBoldItalic'),
-      url(https://fonts.gstatic.com/s/ibmplexserif/v5/jizGREVNn1dOx-zrZ2X3pZvkTiUa4-o3m1bpjfGj7oaMBg.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizGREVNn1dOx-zrZ2X3pZvkTiUa4-o3m1bpjfGj7oaMBg.woff2)
         format('woff2');
     unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB;
   }
@@ -206,7 +206,7 @@
     font-weight: 600;
     src: local('IBM Plex Serif SemiBold Italic'),
       local('IBMPlexSerif-SemiBoldItalic'),
-      url(https://fonts.gstatic.com/s/ibmplexserif/v5/jizGREVNn1dOx-zrZ2X3pZvkTiUa4-o3m1fpjfGj7oaMBg.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizGREVNn1dOx-zrZ2X3pZvkTiUa4-o3m1fpjfGj7oaMBg.woff2)
         format('woff2');
     unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB,
       U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
@@ -218,7 +218,7 @@
     font-weight: 600;
     src: local('IBM Plex Serif SemiBold Italic'),
       local('IBMPlexSerif-SemiBoldItalic'),
-      url(https://fonts.gstatic.com/s/ibmplexserif/v5/jizGREVNn1dOx-zrZ2X3pZvkTiUa4-o3m1npjfGj7oY.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizGREVNn1dOx-zrZ2X3pZvkTiUa4-o3m1npjfGj7oY.woff2)
         format('woff2');
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
       U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212,
@@ -230,7 +230,7 @@
     font-style: normal;
     font-weight: 300;
     src: local('IBM Plex Serif Light'), local('IBMPlexSerif-Light'),
-      url(https://fonts.gstatic.com/s/ibmplexserif/v5/jizAREVNn1dOx-zrZ2X3pZvkTi20-SI5q1vjitOh3oc.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizAREVNn1dOx-zrZ2X3pZvkTi20-SI5q1vjitOh3oc.woff2)
         format('woff2');
     unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F,
       U+FE2E-FE2F;
@@ -241,7 +241,7 @@
     font-style: normal;
     font-weight: 300;
     src: local('IBM Plex Serif Light'), local('IBMPlexSerif-Light'),
-      url(https://fonts.gstatic.com/s/ibmplexserif/v5/jizAREVNn1dOx-zrZ2X3pZvkTi20-SIwq1vjitOh3oc.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizAREVNn1dOx-zrZ2X3pZvkTi20-SIwq1vjitOh3oc.woff2)
         format('woff2');
     unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
   }
@@ -251,7 +251,7 @@
     font-style: normal;
     font-weight: 300;
     src: local('IBM Plex Serif Light'), local('IBMPlexSerif-Light'),
-      url(https://fonts.gstatic.com/s/ibmplexserif/v5/jizAREVNn1dOx-zrZ2X3pZvkTi20-SI7q1vjitOh3oc.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizAREVNn1dOx-zrZ2X3pZvkTi20-SI7q1vjitOh3oc.woff2)
         format('woff2');
     unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB;
   }
@@ -261,7 +261,7 @@
     font-style: normal;
     font-weight: 300;
     src: local('IBM Plex Serif Light'), local('IBMPlexSerif-Light'),
-      url(https://fonts.gstatic.com/s/ibmplexserif/v5/jizAREVNn1dOx-zrZ2X3pZvkTi20-SI6q1vjitOh3oc.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizAREVNn1dOx-zrZ2X3pZvkTi20-SI6q1vjitOh3oc.woff2)
         format('woff2');
     unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB,
       U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
@@ -272,7 +272,7 @@
     font-style: normal;
     font-weight: 300;
     src: local('IBM Plex Serif Light'), local('IBMPlexSerif-Light'),
-      url(https://fonts.gstatic.com/s/ibmplexserif/v5/jizAREVNn1dOx-zrZ2X3pZvkTi20-SI0q1vjitOh.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizAREVNn1dOx-zrZ2X3pZvkTi20-SI0q1vjitOh.woff2)
         format('woff2');
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
       U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212,
@@ -284,7 +284,7 @@
     font-style: normal;
     font-weight: 400;
     src: local('IBM Plex Serif'), local('IBMPlexSerif'),
-      url(https://fonts.gstatic.com/s/ibmplexserif/v5/jizDREVNn1dOx-zrZ2X3pZvkTiUS2zcZiVbJsNo.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizDREVNn1dOx-zrZ2X3pZvkTiUS2zcZiVbJsNo.woff2)
         format('woff2');
     unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F,
       U+FE2E-FE2F;
@@ -295,7 +295,7 @@
     font-style: normal;
     font-weight: 400;
     src: local('IBM Plex Serif'), local('IBMPlexSerif'),
-      url(https://fonts.gstatic.com/s/ibmplexserif/v5/jizDREVNn1dOx-zrZ2X3pZvkTiUb2zcZiVbJsNo.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizDREVNn1dOx-zrZ2X3pZvkTiUb2zcZiVbJsNo.woff2)
         format('woff2');
     unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
   }
@@ -305,7 +305,7 @@
     font-style: normal;
     font-weight: 400;
     src: local('IBM Plex Serif'), local('IBMPlexSerif'),
-      url(https://fonts.gstatic.com/s/ibmplexserif/v5/jizDREVNn1dOx-zrZ2X3pZvkTiUQ2zcZiVbJsNo.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizDREVNn1dOx-zrZ2X3pZvkTiUQ2zcZiVbJsNo.woff2)
         format('woff2');
     unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB;
   }
@@ -315,7 +315,7 @@
     font-style: normal;
     font-weight: 400;
     src: local('IBM Plex Serif'), local('IBMPlexSerif'),
-      url(https://fonts.gstatic.com/s/ibmplexserif/v5/jizDREVNn1dOx-zrZ2X3pZvkTiUR2zcZiVbJsNo.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizDREVNn1dOx-zrZ2X3pZvkTiUR2zcZiVbJsNo.woff2)
         format('woff2');
     unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB,
       U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
@@ -326,7 +326,7 @@
     font-style: normal;
     font-weight: 400;
     src: local('IBM Plex Serif'), local('IBMPlexSerif'),
-      url(https://fonts.gstatic.com/s/ibmplexserif/v5/jizDREVNn1dOx-zrZ2X3pZvkTiUf2zcZiVbJ.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizDREVNn1dOx-zrZ2X3pZvkTiUf2zcZiVbJ.woff2)
         format('woff2');
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
       U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212,
@@ -338,7 +338,7 @@
     font-style: normal;
     font-weight: 600;
     src: local('IBM Plex Serif SemiBold'), local('IBMPlexSerif-SemiBold'),
-      url(https://fonts.gstatic.com/s/ibmplexserif/v5/jizAREVNn1dOx-zrZ2X3pZvkTi3A_yI5q1vjitOh3oc.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizAREVNn1dOx-zrZ2X3pZvkTi3A_yI5q1vjitOh3oc.woff2)
         format('woff2');
     unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F,
       U+FE2E-FE2F;
@@ -349,7 +349,7 @@
     font-style: normal;
     font-weight: 600;
     src: local('IBM Plex Serif SemiBold'), local('IBMPlexSerif-SemiBold'),
-      url(https://fonts.gstatic.com/s/ibmplexserif/v5/jizAREVNn1dOx-zrZ2X3pZvkTi3A_yIwq1vjitOh3oc.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizAREVNn1dOx-zrZ2X3pZvkTi3A_yIwq1vjitOh3oc.woff2)
         format('woff2');
     unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
   }
@@ -359,7 +359,7 @@
     font-style: normal;
     font-weight: 600;
     src: local('IBM Plex Serif SemiBold'), local('IBMPlexSerif-SemiBold'),
-      url(https://fonts.gstatic.com/s/ibmplexserif/v5/jizAREVNn1dOx-zrZ2X3pZvkTi3A_yI7q1vjitOh3oc.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizAREVNn1dOx-zrZ2X3pZvkTi3A_yI7q1vjitOh3oc.woff2)
         format('woff2');
     unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB;
   }
@@ -369,7 +369,7 @@
     font-style: normal;
     font-weight: 600;
     src: local('IBM Plex Serif SemiBold'), local('IBMPlexSerif-SemiBold'),
-      url(https://fonts.gstatic.com/s/ibmplexserif/v5/jizAREVNn1dOx-zrZ2X3pZvkTi3A_yI6q1vjitOh3oc.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizAREVNn1dOx-zrZ2X3pZvkTi3A_yI6q1vjitOh3oc.woff2)
         format('woff2');
     unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB,
       U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
@@ -380,7 +380,7 @@
     font-style: normal;
     font-weight: 600;
     src: local('IBM Plex Serif SemiBold'), local('IBMPlexSerif-SemiBold'),
-      url(https://fonts.gstatic.com/s/ibmplexserif/v5/jizAREVNn1dOx-zrZ2X3pZvkTi3A_yI0q1vjitOh.woff2)
+      url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizAREVNn1dOx-zrZ2X3pZvkTi3A_yI0q1vjitOh.woff2)
         format('woff2');
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
       U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212,


### PR DESCRIPTION
Closes #456

Plex Mono remains unchanged

#### Changelog

**New**

- Support for Greek language subset in IBM Plex Sans

**Changed**

- IBM Plex Sans `v4`→`v6`
- IBM Plex Serif `v5`→`v7`
