### PR TITLE
fix(type): allow type styles to inherit font-family

### DIFF
--- a/packages/type/examples/preview/index.js
+++ b/packages/type/examples/preview/index.js
@@ -20,8 +20,8 @@ function App() {
     <React.Fragment>
       <TableOfContents />
       <FontFaces />
-      <TypeScale />
       <TypeStyles />
+      <TypeScale />
     </React.Fragment>
   );
 }
@@ -35,10 +35,10 @@ function TableOfContents() {
           <a href="#font-faces">Font faces</a>
         </li>
         <li>
-          <a href="#type-scale">Type scale</a>
+          <a href="#type-styles">Type styles</a>
         </li>
         <li>
-          <a href="#type-styles">Type styles</a>
+          <a href="#type-scale">Type scale</a>
         </li>
       </ul>
     </React.Fragment>
@@ -161,6 +161,31 @@ function TypeScale() {
 }
 
 function TypeStyles() {
+  const fontFamilies = [
+    {
+      title: 'Arabic',
+      fontFamily: 'IBM Plex Arabic',
+      sample: 'السادس',
+      dir: 'rtl',
+    },
+    {
+      title: 'Devanagari',
+      fontFamily: 'IBM Plex Devanagari',
+      sample: 'कारन प्रदान',
+    },
+    {
+      title: 'Hebrew',
+      fontFamily: 'IBM Plex Sans Hebrew',
+      sample: 'אחרים בהתייחסות',
+      dir: 'rtl',
+    },
+    {
+      title: 'Thai',
+      fontFamily: 'IBM Plex Thai',
+      sample: 'บลูเบอร์รีแอคทีฟซู',
+    },
+  ];
+
   return (
     <article>
       <header>
@@ -170,8 +195,15 @@ function TypeStyles() {
       <table>
         <thead>
           <tr>
-            <td>Token</td>
-            <td>Sample</td>
+            <th>Token</th>
+            <th>Sample</th>
+            {fontFamilies.map(({ dir, title }) => (
+              <th
+                key={title}
+                style={{ textAlign: dir === 'rtl' ? 'right' : 'left' }}>
+                {title}
+              </th>
+            ))}
           </tr>
         </thead>
         <tbody>
@@ -183,8 +215,17 @@ function TypeStyles() {
                 </pre>
               </td>
               <td className={`bx--type-${formatTokenName(token)}`}>
-                Text sample
+                <span>Text sample</span>
               </td>
+              {fontFamilies.map(({ dir, fontFamily, title, sample }) => (
+                <td
+                  key={title}
+                  className={`bx--type-${formatTokenName(token)}`}
+                  style={{ fontFamily }}
+                  dir={dir}>
+                  <span>{sample}</span>
+                </td>
+              ))}
             </tr>
           ))}
         </tbody>

--- a/packages/type/examples/preview/styles.scss
+++ b/packages/type/examples/preview/styles.scss
@@ -34,6 +34,38 @@
 //------------------------------------------------------------------------------
 // Demo-specific
 //------------------------------------------------------------------------------
+th {
+  text-align: left;
+}
+
 .samples {
   max-width: 560px;
+}
+
+@font-face {
+  font-family: 'IBM Plex Arabic';
+  font-weight: 400;
+  src: url('https://unpkg.com/@ibm/plex@1.3.1/IBM-Plex-Arabic/fonts/complete/woff2/IBMPlexArabic-Regular.woff2')
+    format('woff2');
+}
+
+@font-face {
+  font-family: 'IBM Plex Devanagari';
+  font-weight: 400;
+  src: url('https://unpkg.com/@ibm/plex@1.3.1/IBM-Plex-Devanagari/fonts/complete/woff2/IBMPlexDevanagari-Regular.woff2')
+    format('woff2');
+}
+
+@font-face {
+  font-family: 'IBM Plex Sans Hebrew';
+  font-weight: 400;
+  src: url('https://unpkg.com/@ibm/plex@1.3.1/IBM-Plex-Sans-Hebrew/fonts/complete/woff2/IBMPlexSansHebrew-Regular.woff2')
+    format('woff2');
+}
+
+@font-face {
+  font-family: 'IBM Plex Thai';
+  font-weight: 400;
+  src: url('https://unpkg.com/@ibm/plex@1.3.1/IBM-Plex-Thai/fonts/complete/woff2/IBMPlexThai-Regular.woff2')
+    format('woff2');
 }

--- a/packages/type/scss/_reset.scss
+++ b/packages/type/scss/_reset.scss
@@ -31,12 +31,10 @@
     -moz-osx-font-smoothing: grayscale;
   }
 
-  // IBM Plex Sans uses semibold instead of bold, as a result we need to map
+  // IBM Plex uses semibold instead of bold, as a result we need to map
   // tags that use `font-weight: bold` to the semibold value
-  @if $body-font-family == carbon--font-family('sans') {
-    strong {
-      font-weight: 600;
-    }
+  strong {
+    font-weight: 600;
   }
 
   code {

--- a/packages/type/scss/_reset.scss
+++ b/packages/type/scss/_reset.scss
@@ -8,23 +8,38 @@
 @import '@carbon/layout/scss/convert';
 @import 'font-family';
 
-/// Include a type reset that individuals can use in their projects for
-/// consistent rendering
-@mixin carbon--type-reset() {
+/// Include a type reset for a given body and mono font family.
+/// @param {Number} $base-font-size - the base font size for your document
+/// @param {String} $body-font-family - the font family used on the <body>
+/// element
+/// @param {String} $mono-font-family - the font family used on elements that
+/// require mono fonts, like the <code> element
+@mixin carbon--type-reset(
+  $base-font-size: $carbon--base-font-size,
+  $body-font-family: carbon--font-family('sans'),
+  $mono-font-family: carbon--font-family('mono')
+) {
   html {
-    font-size: $carbon--base-font-size;
+    font-size: $base-font-size;
   }
 
   body {
-    @include carbon--font-family('sans');
-    @include carbon--font-weight('regular');
-
+    font-family: $body-font-family;
+    font-weight: 400;
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }
 
-  strong {
-    font-weight: 600;
+  // IBM Plex Sans uses semibold instead of bold, as a result we need to map
+  // tags that use `font-weight: bold` to the semibold value
+  @if $body-font-family == carbon--font-family('sans') {
+    strong {
+      font-weight: 600;
+    }
+  }
+
+  code {
+    font-family: $mono-font-family;
   }
 }

--- a/packages/type/scss/_styles.scss
+++ b/packages/type/scss/_styles.scss
@@ -6,11 +6,9 @@
 //
 
 @import '@carbon/layout/scss/breakpoint';
-@import 'font-family';
 @import 'scale';
 
 $caption-01: (
-  font-family: carbon--font-family('sans'),
   font-size: carbon--type-scale(1),
   font-weight: carbon--font-weight('regular'),
   line-height: carbon--rem(16px),
@@ -18,7 +16,6 @@ $caption-01: (
 ) !default;
 
 $label-01: (
-  font-family: carbon--font-family('sans'),
   font-size: carbon--type-scale(1),
   font-weight: carbon--font-weight('regular'),
   line-height: carbon--rem(16px),
@@ -26,7 +23,6 @@ $label-01: (
 ) !default;
 
 $helper-text-01: (
-  font-family: carbon--font-family('sans'),
   font-size: carbon--type-scale(1),
   font-style: italic,
   line-height: carbon--rem(16px),
@@ -34,7 +30,6 @@ $helper-text-01: (
 ) !default;
 
 $body-short-01: (
-  font-family: carbon--font-family('sans'),
   font-size: carbon--type-scale(2),
   font-weight: carbon--font-weight('regular'),
   line-height: carbon--rem(18px),
@@ -42,7 +37,6 @@ $body-short-01: (
 ) !default;
 
 $body-long-01: (
-  font-family: carbon--font-family('sans'),
   font-size: carbon--type-scale(2),
   font-weight: carbon--font-weight('regular'),
   line-height: carbon--rem(20px),
@@ -50,7 +44,6 @@ $body-long-01: (
 ) !default;
 
 $body-short-02: (
-  font-family: carbon--font-family('sans'),
   font-size: carbon--type-scale(3),
   font-weight: carbon--font-weight('regular'),
   line-height: carbon--rem(22px),
@@ -58,7 +51,6 @@ $body-short-02: (
 ) !default;
 
 $body-long-02: (
-  font-family: carbon--font-family('sans'),
   font-size: carbon--type-scale(3),
   font-weight: carbon--font-weight('regular'),
   line-height: carbon--rem(24px),
@@ -66,7 +58,6 @@ $body-long-02: (
 ) !default;
 
 $code-01: (
-  font-family: carbon--font-family('mono'),
   font-size: carbon--type-scale(1),
   font-weight: carbon--font-weight('regular'),
   line-height: carbon--rem(16px),
@@ -74,7 +65,6 @@ $code-01: (
 ) !default;
 
 $code-02: (
-  font-family: carbon--font-family('mono'),
   font-size: carbon--type-scale(2),
   font-weight: carbon--font-weight('regular'),
   line-height: carbon--rem(20px),
@@ -82,7 +72,6 @@ $code-02: (
 ) !default;
 
 $heading-01: (
-  font-family: carbon--font-family('sans'),
   font-size: carbon--type-scale(2),
   font-weight: carbon--font-weight('semibold'),
   line-height: carbon--rem(18px),
@@ -90,7 +79,6 @@ $heading-01: (
 ) !default;
 
 $heading-02: (
-  font-family: carbon--font-family('sans'),
   font-size: carbon--type-scale(3),
   font-weight: carbon--font-weight('semibold'),
   line-height: carbon--rem(22px),
@@ -98,7 +86,6 @@ $heading-02: (
 ) !default;
 
 $productive-heading-03: (
-  font-family: carbon--font-family('sans'),
   font-size: carbon--type-scale(5),
   font-weight: carbon--font-weight('regular'),
   line-height: carbon--rem(26px),
@@ -106,7 +93,6 @@ $productive-heading-03: (
 ) !default;
 
 $productive-heading-04: (
-  font-family: carbon--font-family('sans'),
   font-size: carbon--type-scale(7),
   font-weight: carbon--font-weight('regular'),
   line-height: carbon--rem(36px),
@@ -114,7 +100,6 @@ $productive-heading-04: (
 ) !default;
 
 $productive-heading-05: (
-  font-family: carbon--font-family('sans'),
   font-size: carbon--type-scale(8),
   font-weight: carbon--font-weight('regular'),
   line-height: carbon--rem(40px),
@@ -122,7 +107,6 @@ $productive-heading-05: (
 ) !default;
 
 $expressive-heading-03: (
-  font-family: carbon--font-family('sans'),
   font-size: carbon--type-scale(5),
   font-weight: carbon--font-weight('regular'),
   line-height: 130%,
@@ -139,7 +123,6 @@ $expressive-heading-03: (
 ) !default;
 
 $expressive-heading-04: (
-  font-family: carbon--font-family('sans'),
   font-size: carbon--type-scale(7),
   font-weight: carbon--font-weight('regular'),
   line-height: 129%,
@@ -156,7 +139,6 @@ $expressive-heading-04: (
 ) !default;
 
 $expressive-heading-05: (
-  font-family: carbon--font-family('sans'),
   font-size: carbon--type-scale(8),
   font-weight: carbon--font-weight('regular'),
   line-height: 125%,
@@ -181,7 +163,6 @@ $expressive-heading-05: (
 ) !default;
 
 $expressive-heading-06: (
-  font-family: carbon--font-family('sans'),
   font-size: carbon--type-scale(8),
   font-weight: carbon--font-weight('semibold'),
   line-height: 125%,
@@ -206,7 +187,6 @@ $expressive-heading-06: (
 ) !default;
 
 $expressive-paragraph-01: (
-  font-family: carbon--font-family('sans'),
   font-size: carbon--type-scale(6),
   font-weight: carbon--font-weight('light'),
   line-height: 125%,
@@ -224,7 +204,6 @@ $expressive-paragraph-01: (
 );
 
 $quotation-01: (
-  font-family: carbon--font-family('serif'),
   font-size: carbon--type-scale(5),
   font-weight: carbon--font-weight('regular'),
   line-height: 130%,
@@ -249,7 +228,6 @@ $quotation-01: (
 ) !default;
 
 $quotation-02: (
-  font-family: carbon--font-family('serif'),
   font-size: carbon--type-scale(8),
   font-weight: carbon--font-weight('light'),
   line-height: 125%,
@@ -274,7 +252,6 @@ $quotation-02: (
 ) !default;
 
 $display-01: (
-  font-family: carbon--font-family('sans'),
   font-size: carbon--type-scale(10),
   font-weight: carbon--font-weight('light'),
   line-height: 119%,
@@ -298,7 +275,6 @@ $display-01: (
 ) !default;
 
 $display-02: (
-  font-family: carbon--font-family('sans'),
   font-size: carbon--type-scale(10),
   font-weight: carbon--font-weight('semibold'),
   line-height: 119%,
@@ -322,7 +298,6 @@ $display-02: (
 ) !default;
 
 $display-03: (
-  font-family: carbon--font-family('sans'),
   font-size: carbon--type-scale(10),
   font-weight: carbon--font-weight('light'),
   line-height: 119%,
@@ -351,7 +326,6 @@ $display-03: (
 ) !default;
 
 $display-04: (
-  font-family: carbon--font-family('sans'),
   font-size: carbon--type-scale(10),
   font-weight: carbon--font-weight('semibold'),
   line-height: 119%,

--- a/packages/type/src/__tests__/__snapshots__/styles-test.js.snap
+++ b/packages/type/src/__tests__/__snapshots__/styles-test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`styles bodyLong01 should be printable 1`] = `
 Object {
-  "fontFamily": "'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif",
   "fontSize": "0.875rem",
   "fontWeight": 400,
   "letterSpacing": "0.16px",
@@ -11,8 +10,7 @@ Object {
 `;
 
 exports[`styles bodyLong01 should be printable 2`] = `
-"font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
-font-size: 0.875rem;
+"font-size: 0.875rem;
 font-weight: 400;
 line-height: 1.25rem;
 letter-spacing: 0.16px;"
@@ -20,7 +18,6 @@ letter-spacing: 0.16px;"
 
 exports[`styles bodyLong02 should be printable 1`] = `
 Object {
-  "fontFamily": "'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif",
   "fontSize": "1rem",
   "fontWeight": 400,
   "letterSpacing": 0,
@@ -29,8 +26,7 @@ Object {
 `;
 
 exports[`styles bodyLong02 should be printable 2`] = `
-"font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
-font-size: 1rem;
+"font-size: 1rem;
 font-weight: 400;
 line-height: 1.5rem;
 letter-spacing: 0;"
@@ -38,7 +34,6 @@ letter-spacing: 0;"
 
 exports[`styles bodyShort01 should be printable 1`] = `
 Object {
-  "fontFamily": "'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif",
   "fontSize": "0.875rem",
   "fontWeight": 400,
   "letterSpacing": "0.16px",
@@ -47,8 +42,7 @@ Object {
 `;
 
 exports[`styles bodyShort01 should be printable 2`] = `
-"font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
-font-size: 0.875rem;
+"font-size: 0.875rem;
 font-weight: 400;
 line-height: 1.125rem;
 letter-spacing: 0.16px;"
@@ -56,7 +50,6 @@ letter-spacing: 0.16px;"
 
 exports[`styles bodyShort02 should be printable 1`] = `
 Object {
-  "fontFamily": "'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif",
   "fontSize": "1rem",
   "fontWeight": 400,
   "letterSpacing": 0,
@@ -65,8 +58,7 @@ Object {
 `;
 
 exports[`styles bodyShort02 should be printable 2`] = `
-"font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
-font-size: 1rem;
+"font-size: 1rem;
 font-weight: 400;
 line-height: 1.375rem;
 letter-spacing: 0;"
@@ -74,7 +66,6 @@ letter-spacing: 0;"
 
 exports[`styles caption01 should be printable 1`] = `
 Object {
-  "fontFamily": "'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif",
   "fontSize": "0.75rem",
   "fontWeight": 400,
   "letterSpacing": "0.32px",
@@ -83,8 +74,7 @@ Object {
 `;
 
 exports[`styles caption01 should be printable 2`] = `
-"font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
-font-size: 0.75rem;
+"font-size: 0.75rem;
 font-weight: 400;
 line-height: 1rem;
 letter-spacing: 0.32px;"
@@ -92,7 +82,6 @@ letter-spacing: 0.32px;"
 
 exports[`styles code01 should be printable 1`] = `
 Object {
-  "fontFamily": "'IBM Plex Mono', 'Menlo', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', Courier, monospace",
   "fontSize": "0.75rem",
   "fontWeight": 400,
   "letterSpacing": "0.32px",
@@ -101,8 +90,7 @@ Object {
 `;
 
 exports[`styles code01 should be printable 2`] = `
-"font-family: 'IBM Plex Mono', 'Menlo', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', Courier, monospace;
-font-size: 0.75rem;
+"font-size: 0.75rem;
 font-weight: 400;
 line-height: 1rem;
 letter-spacing: 0.32px;"
@@ -110,7 +98,6 @@ letter-spacing: 0.32px;"
 
 exports[`styles code02 should be printable 1`] = `
 Object {
-  "fontFamily": "'IBM Plex Mono', 'Menlo', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', Courier, monospace",
   "fontSize": "0.875rem",
   "fontWeight": 400,
   "letterSpacing": "0.32px",
@@ -119,8 +106,7 @@ Object {
 `;
 
 exports[`styles code02 should be printable 2`] = `
-"font-family: 'IBM Plex Mono', 'Menlo', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', Courier, monospace;
-font-size: 0.875rem;
+"font-size: 0.875rem;
 font-weight: 400;
 line-height: 1.25rem;
 letter-spacing: 0.32px;"
@@ -142,7 +128,6 @@ Object {
     "fontSize": "4.75rem",
     "lineHeight": "113%",
   },
-  "fontFamily": "'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif",
   "fontSize": "calc(2.625rem + 0 * ((100vw - 20rem) / 22))",
   "fontWeight": 300,
   "letterSpacing": 0,
@@ -151,8 +136,7 @@ Object {
 `;
 
 exports[`styles display01 should be printable 2`] = `
-"font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
-font-size: calc(2.625rem + 0 * ((100vw - 20rem) / 22));
+"font-size: calc(2.625rem + 0 * ((100vw - 20rem) / 22));
 font-weight: 300;
 line-height: 119%;
 letter-spacing: 0;
@@ -178,7 +162,6 @@ Object {
     "fontSize": "4.75rem",
     "lineHeight": "113%",
   },
-  "fontFamily": "'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif",
   "fontSize": "calc(2.625rem + 0 * ((100vw - 20rem) / 22))",
   "fontWeight": 600,
   "letterSpacing": 0,
@@ -187,8 +170,7 @@ Object {
 `;
 
 exports[`styles display02 should be printable 2`] = `
-"font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
-font-size: calc(2.625rem + 0 * ((100vw - 20rem) / 22));
+"font-size: calc(2.625rem + 0 * ((100vw - 20rem) / 22));
 font-weight: 600;
 line-height: 119%;
 letter-spacing: 0;
@@ -218,7 +200,6 @@ Object {
     "letterSpacing": "-0.96px",
     "lineHeight": "105%",
   },
-  "fontFamily": "'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif",
   "fontSize": "calc(2.625rem + 1.625 * ((100vw - 20rem) / 22))",
   "fontWeight": 300,
   "letterSpacing": 0,
@@ -227,8 +208,7 @@ Object {
 `;
 
 exports[`styles display03 should be printable 2`] = `
-"font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
-font-size: calc(2.625rem + 1.625 * ((100vw - 20rem) / 22));
+"font-size: calc(2.625rem + 1.625 * ((100vw - 20rem) / 22));
 font-weight: 300;
 line-height: 119%;
 letter-spacing: 0;
@@ -259,7 +239,6 @@ Object {
     "letterSpacing": "-0.96px",
     "lineHeight": "105%",
   },
-  "fontFamily": "'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif",
   "fontSize": "calc(2.625rem + 1.625 * ((100vw - 20rem) / 22))",
   "fontWeight": 600,
   "letterSpacing": 0,
@@ -268,8 +247,7 @@ Object {
 `;
 
 exports[`styles display04 should be printable 2`] = `
-"font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
-font-size: calc(2.625rem + 1.625 * ((100vw - 20rem) / 22));
+"font-size: calc(2.625rem + 1.625 * ((100vw - 20rem) / 22));
 font-weight: 600;
 line-height: 119%;
 letter-spacing: 0;
@@ -288,7 +266,6 @@ Object {
   "@media (min-width: 99rem)": Object {
     "fontSize": "1.5rem",
   },
-  "fontFamily": "'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif",
   "fontSize": "calc(1.25rem + 0 * ((100vw - 20rem) / 62))",
   "fontWeight": 400,
   "letterSpacing": 0,
@@ -297,8 +274,7 @@ Object {
 `;
 
 exports[`styles expressiveHeading03 should be printable 2`] = `
-"font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
-font-size: calc(1.25rem + 0 * ((100vw - 20rem) / 62));
+"font-size: calc(1.25rem + 0 * ((100vw - 20rem) / 62));
 font-weight: 400;
 line-height: 130%;
 letter-spacing: 0;
@@ -315,7 +291,6 @@ Object {
   "@media (min-width: 99rem)": Object {
     "fontSize": "2rem",
   },
-  "fontFamily": "'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif",
   "fontSize": "calc(1.75rem + 0 * ((100vw - 20rem) / 62))",
   "fontWeight": 400,
   "letterSpacing": 0,
@@ -324,8 +299,7 @@ Object {
 `;
 
 exports[`styles expressiveHeading04 should be printable 2`] = `
-"font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
-font-size: calc(1.75rem + 0 * ((100vw - 20rem) / 62));
+"font-size: calc(1.75rem + 0 * ((100vw - 20rem) / 62));
 font-weight: 400;
 line-height: 129%;
 letter-spacing: 0;
@@ -336,34 +310,29 @@ letter-spacing: 0;
 exports[`styles expressiveHeading05 should be printable 1`] = `
 Object {
   "@media (min-width: 42rem)": Object {
-    "fontFamily": "'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif",
     "fontSize": "calc(2.25rem + 0.375 * ((100vw - 42rem) / 24))",
     "fontWeight": 300,
     "letterSpacing": 0,
     "lineHeight": "122%",
   },
   "@media (min-width: 66rem)": Object {
-    "fontFamily": "'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif",
     "fontSize": "calc(2.625rem + 0.375 * ((100vw - 66rem) / 16))",
     "fontWeight": 300,
     "letterSpacing": 0,
     "lineHeight": "119%",
   },
   "@media (min-width: 82rem)": Object {
-    "fontFamily": "'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif",
     "fontSize": "calc(3rem + 0.75 * ((100vw - 82rem) / 17))",
     "fontWeight": 300,
     "letterSpacing": 0,
     "lineHeight": "117%",
   },
   "@media (min-width: 99rem)": Object {
-    "fontFamily": "'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif",
     "fontSize": "3.75rem",
     "fontWeight": 300,
     "letterSpacing": 0,
     "lineHeight": "4.375rem",
   },
-  "fontFamily": "'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif",
   "fontSize": "calc(2rem + 0.25 * ((100vw - 20rem) / 22))",
   "fontWeight": 400,
   "letterSpacing": 0,
@@ -372,8 +341,7 @@ Object {
 `;
 
 exports[`styles expressiveHeading05 should be printable 2`] = `
-"font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
-font-size: calc(2rem + 0.25 * ((100vw - 20rem) / 22));
+"font-size: calc(2rem + 0.25 * ((100vw - 20rem) / 22));
 font-weight: 400;
 line-height: 125%;
 letter-spacing: 0;
@@ -386,34 +354,29 @@ letter-spacing: 0;
 exports[`styles expressiveHeading06 should be printable 1`] = `
 Object {
   "@media (min-width: 42rem)": Object {
-    "fontFamily": "'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif",
     "fontSize": "calc(2.25rem + 0.375 * ((100vw - 42rem) / 24))",
     "fontWeight": 600,
     "letterSpacing": 0,
     "lineHeight": "122%",
   },
   "@media (min-width: 66rem)": Object {
-    "fontFamily": "'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif",
     "fontSize": "calc(2.625rem + 0.375 * ((100vw - 66rem) / 16))",
     "fontWeight": 600,
     "letterSpacing": 0,
     "lineHeight": "119%",
   },
   "@media (min-width: 82rem)": Object {
-    "fontFamily": "'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif",
     "fontSize": "calc(3rem + 0.75 * ((100vw - 82rem) / 17))",
     "fontWeight": 600,
     "letterSpacing": 0,
     "lineHeight": "117%",
   },
   "@media (min-width: 99rem)": Object {
-    "fontFamily": "'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif",
     "fontSize": "3.75rem",
     "fontWeight": 600,
     "letterSpacing": 0,
     "lineHeight": "4.375rem",
   },
-  "fontFamily": "'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif",
   "fontSize": "calc(2rem + 0.25 * ((100vw - 20rem) / 22))",
   "fontWeight": 600,
   "letterSpacing": 0,
@@ -422,8 +385,7 @@ Object {
 `;
 
 exports[`styles expressiveHeading06 should be printable 2`] = `
-"font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
-font-size: calc(2rem + 0.25 * ((100vw - 20rem) / 22));
+"font-size: calc(2rem + 0.25 * ((100vw - 20rem) / 22));
 font-weight: 600;
 line-height: 125%;
 letter-spacing: 0;
@@ -435,7 +397,6 @@ letter-spacing: 0;
 
 exports[`styles expressiveParagraph01 should be printable 1`] = `
 Object {
-  "fontFamily": "'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif",
   "fontSize": "1.5rem",
   "fontWeight": 300,
   "letterSpacing": 0,
@@ -452,8 +413,7 @@ Object {
 `;
 
 exports[`styles expressiveParagraph01 should be printable 2`] = `
-"font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
-font-size: 1.5rem;
+"font-size: 1.5rem;
 font-weight: 300;
 line-height: 125%;
 letter-spacing: 0;
@@ -463,7 +423,6 @@ max: [object Object];"
 
 exports[`styles heading01 should be printable 1`] = `
 Object {
-  "fontFamily": "'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif",
   "fontSize": "0.875rem",
   "fontWeight": 600,
   "letterSpacing": "0.16px",
@@ -472,8 +431,7 @@ Object {
 `;
 
 exports[`styles heading01 should be printable 2`] = `
-"font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
-font-size: 0.875rem;
+"font-size: 0.875rem;
 font-weight: 600;
 line-height: 1.125rem;
 letter-spacing: 0.16px;"
@@ -481,7 +439,6 @@ letter-spacing: 0.16px;"
 
 exports[`styles heading02 should be printable 1`] = `
 Object {
-  "fontFamily": "'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif",
   "fontSize": "1rem",
   "fontWeight": 600,
   "letterSpacing": 0,
@@ -490,8 +447,7 @@ Object {
 `;
 
 exports[`styles heading02 should be printable 2`] = `
-"font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
-font-size: 1rem;
+"font-size: 1rem;
 font-weight: 600;
 line-height: 1.375rem;
 letter-spacing: 0;"
@@ -499,7 +455,6 @@ letter-spacing: 0;"
 
 exports[`styles helperText01 should be printable 1`] = `
 Object {
-  "fontFamily": "'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif",
   "fontSize": "0.75rem",
   "fontStyle": "italic",
   "letterSpacing": "0.32px",
@@ -508,8 +463,7 @@ Object {
 `;
 
 exports[`styles helperText01 should be printable 2`] = `
-"font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
-font-size: 0.75rem;
+"font-size: 0.75rem;
 font-style: italic;
 line-height: 1rem;
 letter-spacing: 0.32px;"
@@ -517,7 +471,6 @@ letter-spacing: 0.32px;"
 
 exports[`styles label01 should be printable 1`] = `
 Object {
-  "fontFamily": "'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif",
   "fontSize": "0.75rem",
   "fontWeight": 400,
   "letterSpacing": "0.32px",
@@ -526,8 +479,7 @@ Object {
 `;
 
 exports[`styles label01 should be printable 2`] = `
-"font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
-font-size: 0.75rem;
+"font-size: 0.75rem;
 font-weight: 400;
 line-height: 1rem;
 letter-spacing: 0.32px;"
@@ -535,7 +487,6 @@ letter-spacing: 0.32px;"
 
 exports[`styles productiveHeading03 should be printable 1`] = `
 Object {
-  "fontFamily": "'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif",
   "fontSize": "1.25rem",
   "fontWeight": 400,
   "letterSpacing": 0,
@@ -544,8 +495,7 @@ Object {
 `;
 
 exports[`styles productiveHeading03 should be printable 2`] = `
-"font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
-font-size: 1.25rem;
+"font-size: 1.25rem;
 font-weight: 400;
 line-height: 1.625rem;
 letter-spacing: 0;"
@@ -553,7 +503,6 @@ letter-spacing: 0;"
 
 exports[`styles productiveHeading04 should be printable 1`] = `
 Object {
-  "fontFamily": "'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif",
   "fontSize": "1.75rem",
   "fontWeight": 400,
   "letterSpacing": 0,
@@ -562,8 +511,7 @@ Object {
 `;
 
 exports[`styles productiveHeading04 should be printable 2`] = `
-"font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
-font-size: 1.75rem;
+"font-size: 1.75rem;
 font-weight: 400;
 line-height: 2.25rem;
 letter-spacing: 0;"
@@ -571,7 +519,6 @@ letter-spacing: 0;"
 
 exports[`styles productiveHeading05 should be printable 1`] = `
 Object {
-  "fontFamily": "'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif",
   "fontSize": "2rem",
   "fontWeight": 400,
   "letterSpacing": 0,
@@ -580,8 +527,7 @@ Object {
 `;
 
 exports[`styles productiveHeading05 should be printable 2`] = `
-"font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
-font-size: 2rem;
+"font-size: 2rem;
 font-weight: 400;
 line-height: 2.5rem;
 letter-spacing: 0;"
@@ -590,33 +536,28 @@ letter-spacing: 0;"
 exports[`styles quotation01 should be printable 1`] = `
 Object {
   "@media (min-width: 42rem)": Object {
-    "fontFamily": "'IBM Plex Serif', 'Georgia', Times, serif",
     "fontSize": "calc(1.25rem + 0.25 * ((100vw - 42rem) / 24))",
     "fontWeight": 400,
     "letterSpacing": 0,
   },
   "@media (min-width: 66rem)": Object {
-    "fontFamily": "'IBM Plex Serif', 'Georgia', Times, serif",
     "fontSize": "calc(1.5rem + 0.25 * ((100vw - 66rem) / 16))",
     "fontWeight": 400,
     "letterSpacing": 0,
     "lineHeight": "125%",
   },
   "@media (min-width: 82rem)": Object {
-    "fontFamily": "'IBM Plex Serif', 'Georgia', Times, serif",
     "fontSize": "calc(1.75rem + 0.25 * ((100vw - 82rem) / 17))",
     "fontWeight": 400,
     "letterSpacing": 0,
     "lineHeight": "129%",
   },
   "@media (min-width: 99rem)": Object {
-    "fontFamily": "'IBM Plex Serif', 'Georgia', Times, serif",
     "fontSize": "2rem",
     "fontWeight": 400,
     "letterSpacing": 0,
     "lineHeight": "125%",
   },
-  "fontFamily": "'IBM Plex Serif', 'Georgia', Times, serif",
   "fontSize": "calc(1.25rem + 0 * ((100vw - 20rem) / 22))",
   "fontWeight": 400,
   "letterSpacing": 0,
@@ -625,8 +566,7 @@ Object {
 `;
 
 exports[`styles quotation01 should be printable 2`] = `
-"font-family: 'IBM Plex Serif', 'Georgia', Times, serif;
-font-size: calc(1.25rem + 0 * ((100vw - 20rem) / 22));
+"font-size: calc(1.25rem + 0 * ((100vw - 20rem) / 22));
 font-weight: 400;
 line-height: 130%;
 letter-spacing: 0;
@@ -653,7 +593,6 @@ Object {
   "@media (min-width: 99rem)": Object {
     "fontSize": "3.75rem",
   },
-  "fontFamily": "'IBM Plex Serif', 'Georgia', Times, serif",
   "fontSize": "calc(2rem + 0.25 * ((100vw - 20rem) / 22))",
   "fontWeight": 300,
   "letterSpacing": 0,
@@ -662,8 +601,7 @@ Object {
 `;
 
 exports[`styles quotation02 should be printable 2`] = `
-"font-family: 'IBM Plex Serif', 'Georgia', Times, serif;
-font-size: calc(2rem + 0.25 * ((100vw - 20rem) / 22));
+"font-size: calc(2rem + 0.25 * ((100vw - 20rem) / 22));
 font-weight: 300;
 line-height: 125%;
 letter-spacing: 0;

--- a/packages/type/src/__tests__/fluid-test.js
+++ b/packages/type/src/__tests__/fluid-test.js
@@ -61,7 +61,6 @@ Object {
     "letterSpacing": "-0.96px",
     "lineHeight": "105%",
   },
-  "fontFamily": "'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif",
   "fontSize": "calc(2.625rem + 1.625 * ((100vw - 20rem) / 22))",
   "fontWeight": 600,
   "letterSpacing": 0,

--- a/packages/type/src/reset.js
+++ b/packages/type/src/reset.js
@@ -23,4 +23,7 @@ export const reset = {
   strong: {
     fontWeight: fontWeights.semibold,
   },
+  code: {
+    fontFamily: fontFamilies.mono,
+  },
 };

--- a/packages/type/src/styles.js
+++ b/packages/type/src/styles.js
@@ -7,12 +7,10 @@
 
 import { breakpoint, breakpoints, px, rem } from '@carbon/layout';
 import { fluid } from './fluid';
-import { fontFamilies } from './fontFamily';
 import { fontWeights } from './fontWeight';
 import { scale } from './scale';
 
 export const caption01 = {
-  fontFamily: fontFamilies.sans,
   fontSize: rem(scale[0]),
   fontWeight: fontWeights.regular,
   lineHeight: rem(16),
@@ -20,7 +18,6 @@ export const caption01 = {
 };
 
 export const label01 = {
-  fontFamily: fontFamilies.sans,
   fontSize: rem(scale[0]),
   fontWeight: fontWeights.regular,
   lineHeight: rem(16),
@@ -28,7 +25,6 @@ export const label01 = {
 };
 
 export const helperText01 = {
-  fontFamily: fontFamilies.sans,
   fontSize: rem(scale[0]),
   fontStyle: 'italic',
   lineHeight: rem(16),
@@ -36,7 +32,6 @@ export const helperText01 = {
 };
 
 export const bodyShort01 = {
-  fontFamily: fontFamilies.sans,
   fontSize: rem(scale[1]),
   fontWeight: fontWeights.regular,
   lineHeight: rem(18),
@@ -44,7 +39,6 @@ export const bodyShort01 = {
 };
 
 export const bodyLong01 = {
-  fontFamily: fontFamilies.sans,
   fontSize: rem(scale[1]),
   fontWeight: fontWeights.regular,
   lineHeight: rem(20),
@@ -52,7 +46,6 @@ export const bodyLong01 = {
 };
 
 export const bodyShort02 = {
-  fontFamily: fontFamilies.sans,
   fontSize: rem(scale[2]),
   fontWeight: fontWeights.regular,
   lineHeight: rem(22),
@@ -60,7 +53,6 @@ export const bodyShort02 = {
 };
 
 export const bodyLong02 = {
-  fontFamily: fontFamilies.sans,
   fontSize: rem(scale[2]),
   fontWeight: fontWeights.regular,
   lineHeight: rem(24),
@@ -68,7 +60,6 @@ export const bodyLong02 = {
 };
 
 export const code01 = {
-  fontFamily: fontFamilies.mono,
   fontSize: rem(scale[0]),
   fontWeight: fontWeights.regular,
   lineHeight: rem(16),
@@ -76,7 +67,6 @@ export const code01 = {
 };
 
 export const code02 = {
-  fontFamily: fontFamilies.mono,
   fontSize: rem(scale[1]),
   fontWeight: fontWeights.regular,
   lineHeight: rem(20),
@@ -84,7 +74,6 @@ export const code02 = {
 };
 
 export const heading01 = {
-  fontFamily: fontFamilies.sans,
   fontSize: rem(scale[1]),
   fontWeight: fontWeights.semibold,
   lineHeight: rem(18),
@@ -92,7 +81,6 @@ export const heading01 = {
 };
 
 export const heading02 = {
-  fontFamily: fontFamilies.sans,
   fontSize: rem(scale[2]),
   fontWeight: fontWeights.semibold,
   lineHeight: rem(22),
@@ -100,7 +88,6 @@ export const heading02 = {
 };
 
 export const productiveHeading03 = {
-  fontFamily: fontFamilies.sans,
   fontSize: rem(scale[4]),
   fontWeight: fontWeights.regular,
   lineHeight: rem(26),
@@ -108,7 +95,6 @@ export const productiveHeading03 = {
 };
 
 export const productiveHeading04 = {
-  fontFamily: fontFamilies.sans,
   fontSize: rem(scale[6]),
   fontWeight: fontWeights.regular,
   lineHeight: rem(36),
@@ -116,7 +102,6 @@ export const productiveHeading04 = {
 };
 
 export const productiveHeading05 = {
-  fontFamily: fontFamilies.sans,
   fontSize: rem(scale[7]),
   fontWeight: fontWeights.regular,
   lineHeight: rem(40),
@@ -124,7 +109,6 @@ export const productiveHeading05 = {
 };
 
 export const expressiveHeading03 = fluid({
-  fontFamily: fontFamilies.sans,
   fontSize: rem(scale[4]),
   fontWeight: fontWeights.regular,
   lineHeight: '130%',
@@ -141,7 +125,6 @@ export const expressiveHeading03 = fluid({
 });
 
 export const expressiveHeading04 = fluid({
-  fontFamily: fontFamilies.sans,
   fontSize: rem(scale[6]),
   fontWeight: fontWeights.regular,
   lineHeight: '129%',
@@ -158,7 +141,6 @@ export const expressiveHeading04 = fluid({
 });
 
 export const expressiveHeading05 = fluid({
-  fontFamily: fontFamilies.sans,
   fontSize: rem(scale[7]),
   fontWeight: fontWeights.regular,
   lineHeight: '125%',
@@ -166,28 +148,24 @@ export const expressiveHeading05 = fluid({
   breakpoints: {
     md: {
       fontSize: rem(scale[8]),
-      fontFamily: fontFamilies.sans,
       fontWeight: fontWeights.light,
       lineHeight: '122%',
       letterSpacing: 0,
     },
     lg: {
       fontSize: rem(scale[9]),
-      fontFamily: fontFamilies.sans,
       fontWeight: fontWeights.light,
       lineHeight: '119%',
       letterSpacing: 0,
     },
     xlg: {
       fontSize: rem(scale[10]),
-      fontFamily: fontFamilies.sans,
       fontWeight: fontWeights.light,
       lineHeight: '117%',
       letterSpacing: 0,
     },
     max: {
       fontSize: rem(scale[12]),
-      fontFamily: fontFamilies.sans,
       fontWeight: fontWeights.light,
       lineHeight: rem(70),
       letterSpacing: 0,
@@ -196,7 +174,6 @@ export const expressiveHeading05 = fluid({
 });
 
 export const expressiveHeading06 = fluid({
-  fontFamily: fontFamilies.sans,
   fontSize: rem(scale[7]),
   fontWeight: fontWeights.semibold,
   lineHeight: '125%',
@@ -204,28 +181,24 @@ export const expressiveHeading06 = fluid({
   breakpoints: {
     md: {
       fontSize: rem(scale[8]),
-      fontFamily: fontFamilies.sans,
       fontWeight: fontWeights.semibold,
       lineHeight: '122%',
       letterSpacing: 0,
     },
     lg: {
       fontSize: rem(scale[9]),
-      fontFamily: fontFamilies.sans,
       fontWeight: fontWeights.semibold,
       lineHeight: '119%',
       letterSpacing: 0,
     },
     xlg: {
       fontSize: rem(scale[10]),
-      fontFamily: fontFamilies.sans,
       fontWeight: fontWeights.semibold,
       lineHeight: '117%',
       letterSpacing: 0,
     },
     max: {
       fontSize: rem(scale[12]),
-      fontFamily: fontFamilies.sans,
       fontWeight: fontWeights.semibold,
       lineHeight: rem(70),
       letterSpacing: 0,
@@ -234,7 +207,6 @@ export const expressiveHeading06 = fluid({
 });
 
 export const expressiveParagraph01 = fluid({
-  fontFamily: fontFamilies.sans,
   fontSize: rem(scale[5]),
   fontWeight: fontWeights.light,
   lineHeight: '125%',
@@ -250,7 +222,6 @@ export const expressiveParagraph01 = fluid({
 });
 
 export const quotation01 = fluid({
-  fontFamily: fontFamilies.serif,
   fontSize: rem(scale[4]),
   fontWeight: fontWeights.regular,
   lineHeight: '130%',
@@ -258,27 +229,23 @@ export const quotation01 = fluid({
   breakpoints: {
     md: {
       fontSize: rem(scale[4]),
-      fontFamily: fontFamilies.serif,
       fontWeight: fontWeights.regular,
       letterSpacing: 0,
     },
     lg: {
       fontSize: rem(scale[5]),
-      fontFamily: fontFamilies.serif,
       fontWeight: fontWeights.regular,
       lineHeight: '125%',
       letterSpacing: 0,
     },
     xlg: {
       fontSize: rem(scale[6]),
-      fontFamily: fontFamilies.serif,
       fontWeight: fontWeights.regular,
       lineHeight: '129%',
       letterSpacing: 0,
     },
     max: {
       fontSize: rem(scale[7]),
-      fontFamily: fontFamilies.serif,
       fontWeight: fontWeights.regular,
       lineHeight: '125%',
       letterSpacing: 0,
@@ -287,7 +254,6 @@ export const quotation01 = fluid({
 });
 
 export const quotation02 = fluid({
-  fontFamily: fontFamilies.serif,
   fontSize: rem(scale[7]),
   fontWeight: fontWeights.light,
   lineHeight: '125%',
@@ -312,7 +278,6 @@ export const quotation02 = fluid({
 });
 
 export const display01 = fluid({
-  fontFamily: fontFamilies.sans,
   fontSize: rem(scale[9]),
   fontWeight: fontWeights.light,
   lineHeight: '119%',
@@ -336,7 +301,6 @@ export const display01 = fluid({
 });
 
 export const display02 = fluid({
-  fontFamily: fontFamilies.sans,
   fontSize: rem(scale[9]),
   fontWeight: fontWeights.semibold,
   lineHeight: '119%',
@@ -360,7 +324,6 @@ export const display02 = fluid({
 });
 
 export const display03 = fluid({
-  fontFamily: fontFamilies.sans,
   fontSize: rem(scale[9]),
   fontWeight: fontWeights.light,
   lineHeight: '119%',
@@ -388,7 +351,6 @@ export const display03 = fluid({
 });
 
 export const display04 = fluid({
-  fontFamily: fontFamilies.sans,
   fontSize: rem(scale[9]),
   fontWeight: fontWeights.semibold,
   lineHeight: '119%',


### PR DESCRIPTION
Part of #393, we need to support alternative `font-family` definitions for our type styles. The update to the preview example is to show that these styles should work in other languages.

#### Changelog

**New**

**Changed**

- Type styles no longer include `font-family` in their definition
- The type reset now has optional body/mono/base-font-size arguments

**Removed**
