### PR TITLE
docs(migration): update to correct token name

### DIFF
--- a/docs/migration/10.x-color.md
+++ b/docs/migration/10.x-color.md
@@ -20,9 +20,9 @@ Legend:
 
 | v9                     | v10                            |
 | ---------------------- | ------------------------------ |
-| `brand-01`             | replaced with `interaction-01` |
-| `brand-02`             | replaced with `interaction-02` |
-| `brand-03`             | replaced with `interaction-03` |
+| `brand-01`             | replaced with `interactive-01` |
+| `brand-02`             | replaced with `interactive-02` |
+| `brand-03`             | replaced with `interactive-03` |
 |                        | ✨ `interaction-04`            |
 | `ui-01`                | No change                      |
 | `ui-02`                | No change                      |


### PR DESCRIPTION
Closes #466

Fix typo in migration guide

#### Changelog

**New**

**Changed**

- `docs/migration/10.x-color.md` now uses `interactive` token naming

**Removed**
