### PR TITLE
feat: add font-display setting to enhance font loading experience

### DIFF
--- a/packages/type/scss/font-face/_mono.scss
+++ b/packages/type/scss/font-face/_mono.scss
@@ -5,12 +5,15 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+@import 'settings';
+
 @mixin carbon--font-face-mono {
   // .woff support for IE11
   @font-face {
     font-family: 'IBM Plex Mono';
     font-style: italic;
     font-weight: 300;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Mono Light Italic'), local('IBMPlexMono-LightItalic'),
       url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6sfjptAgt5VM-kVkqdyU8n1ioSflV1gMoW.woff)
         format('woff');
@@ -19,6 +22,7 @@
     font-family: 'IBM Plex Mono';
     font-style: italic;
     font-weight: 400;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Mono Italic'), local('IBMPlexMono-Italic'),
       url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6pfjptAgt5VM-kVkqdyU8n1ioa1Xdm.woff)
         format('woff');
@@ -27,6 +31,7 @@
     font-family: 'IBM Plex Mono';
     font-style: italic;
     font-weight: 600;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Mono SemiBold Italic'),
       local('IBMPlexMono-SemiBoldItalic'),
       url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6sfjptAgt5VM-kVkqdyU8n1ioSClN1gMoW.woff)
@@ -36,6 +41,7 @@
     font-family: 'IBM Plex Mono';
     font-style: normal;
     font-weight: 300;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Mono Light'), local('IBMPlexMono-Light'),
       url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6qfjptAgt5VM-kVkqdyU8n3oQIwlBFhA.woff)
         format('woff');
@@ -44,6 +50,7 @@
     font-family: 'IBM Plex Mono';
     font-style: normal;
     font-weight: 400;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Mono'), local('IBMPlexMono'),
       url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F63fjptAgt5VM-kVkqdyU8n1i8q0Q.woff)
         format('woff');
@@ -52,6 +59,7 @@
     font-family: 'IBM Plex Mono';
     font-style: normal;
     font-weight: 600;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Mono SemiBold'), local('IBMPlexMono-SemiBold'),
       url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6qfjptAgt5VM-kVkqdyU8n3vAOwlBFhA.woff)
         format('woff');
@@ -62,6 +70,7 @@
     font-family: 'IBM Plex Mono';
     font-style: italic;
     font-weight: 300;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Mono Light Italic'), local('IBMPlexMono-LightItalic'),
       url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6sfjptAgt5VM-kVkqdyU8n1ioSflV1jcoQPttoz6Pz.woff2)
         format('woff2');
@@ -73,6 +82,7 @@
     font-family: 'IBM Plex Mono';
     font-style: italic;
     font-weight: 300;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Mono Light Italic'), local('IBMPlexMono-LightItalic'),
       url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6sfjptAgt5VM-kVkqdyU8n1ioSflV1hMoQPttoz6Pz.woff2)
         format('woff2');
@@ -83,6 +93,7 @@
     font-family: 'IBM Plex Mono';
     font-style: italic;
     font-weight: 300;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Mono Light Italic'), local('IBMPlexMono-LightItalic'),
       url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6sfjptAgt5VM-kVkqdyU8n1ioSflV1j8oQPttoz6Pz.woff2)
         format('woff2');
@@ -93,6 +104,7 @@
     font-family: 'IBM Plex Mono';
     font-style: italic;
     font-weight: 300;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Mono Light Italic'), local('IBMPlexMono-LightItalic'),
       url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6sfjptAgt5VM-kVkqdyU8n1ioSflV1jsoQPttoz6Pz.woff2)
         format('woff2');
@@ -104,6 +116,7 @@
     font-family: 'IBM Plex Mono';
     font-style: italic;
     font-weight: 300;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Mono Light Italic'), local('IBMPlexMono-LightItalic'),
       url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6sfjptAgt5VM-kVkqdyU8n1ioSflV1gMoQPttozw.woff2)
         format('woff2');
@@ -116,6 +129,7 @@
     font-family: 'IBM Plex Mono';
     font-style: italic;
     font-weight: 400;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Mono Italic'), local('IBMPlexMono-Italic'),
       url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6pfjptAgt5VM-kVkqdyU8n1ioa2HdgregdFOFh.woff2)
         format('woff2');
@@ -127,6 +141,7 @@
     font-family: 'IBM Plex Mono';
     font-style: italic;
     font-weight: 400;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Mono Italic'), local('IBMPlexMono-Italic'),
       url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6pfjptAgt5VM-kVkqdyU8n1ioa0XdgregdFOFh.woff2)
         format('woff2');
@@ -137,6 +152,7 @@
     font-family: 'IBM Plex Mono';
     font-style: italic;
     font-weight: 400;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Mono Italic'), local('IBMPlexMono-Italic'),
       url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6pfjptAgt5VM-kVkqdyU8n1ioa2ndgregdFOFh.woff2)
         format('woff2');
@@ -147,6 +163,7 @@
     font-family: 'IBM Plex Mono';
     font-style: italic;
     font-weight: 400;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Mono Italic'), local('IBMPlexMono-Italic'),
       url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6pfjptAgt5VM-kVkqdyU8n1ioa23dgregdFOFh.woff2)
         format('woff2');
@@ -158,6 +175,7 @@
     font-family: 'IBM Plex Mono';
     font-style: italic;
     font-weight: 400;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Mono Italic'), local('IBMPlexMono-Italic'),
       url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6pfjptAgt5VM-kVkqdyU8n1ioa1XdgregdFA.woff2)
         format('woff2');
@@ -170,6 +188,7 @@
     font-family: 'IBM Plex Mono';
     font-style: italic;
     font-weight: 600;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Mono SemiBold Italic'),
       local('IBMPlexMono-SemiBoldItalic'),
       url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6sfjptAgt5VM-kVkqdyU8n1ioSClN1jcoQPttoz6Pz.woff2)
@@ -182,6 +201,7 @@
     font-family: 'IBM Plex Mono';
     font-style: italic;
     font-weight: 600;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Mono SemiBold Italic'),
       local('IBMPlexMono-SemiBoldItalic'),
       url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6sfjptAgt5VM-kVkqdyU8n1ioSClN1hMoQPttoz6Pz.woff2)
@@ -193,6 +213,7 @@
     font-family: 'IBM Plex Mono';
     font-style: italic;
     font-weight: 600;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Mono SemiBold Italic'),
       local('IBMPlexMono-SemiBoldItalic'),
       url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6sfjptAgt5VM-kVkqdyU8n1ioSClN1j8oQPttoz6Pz.woff2)
@@ -204,6 +225,7 @@
     font-family: 'IBM Plex Mono';
     font-style: italic;
     font-weight: 600;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Mono SemiBold Italic'),
       local('IBMPlexMono-SemiBoldItalic'),
       url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6sfjptAgt5VM-kVkqdyU8n1ioSClN1jsoQPttoz6Pz.woff2)
@@ -216,6 +238,7 @@
     font-family: 'IBM Plex Mono';
     font-style: italic;
     font-weight: 600;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Mono SemiBold Italic'),
       local('IBMPlexMono-SemiBoldItalic'),
       url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6sfjptAgt5VM-kVkqdyU8n1ioSClN1gMoQPttozw.woff2)
@@ -229,6 +252,7 @@
     font-family: 'IBM Plex Mono';
     font-style: normal;
     font-weight: 300;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Mono Light'), local('IBMPlexMono-Light'),
       url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6qfjptAgt5VM-kVkqdyU8n3oQIwl1FgsAXHNlYzg.woff2)
         format('woff2');
@@ -240,6 +264,7 @@
     font-family: 'IBM Plex Mono';
     font-style: normal;
     font-weight: 300;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Mono Light'), local('IBMPlexMono-Light'),
       url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6qfjptAgt5VM-kVkqdyU8n3oQIwlRFgsAXHNlYzg.woff2)
         format('woff2');
@@ -250,6 +275,7 @@
     font-family: 'IBM Plex Mono';
     font-style: normal;
     font-weight: 300;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Mono Light'), local('IBMPlexMono-Light'),
       url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6qfjptAgt5VM-kVkqdyU8n3oQIwl9FgsAXHNlYzg.woff2)
         format('woff2');
@@ -260,6 +286,7 @@
     font-family: 'IBM Plex Mono';
     font-style: normal;
     font-weight: 300;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Mono Light'), local('IBMPlexMono-Light'),
       url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6qfjptAgt5VM-kVkqdyU8n3oQIwl5FgsAXHNlYzg.woff2)
         format('woff2');
@@ -271,6 +298,7 @@
     font-family: 'IBM Plex Mono';
     font-style: normal;
     font-weight: 300;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Mono Light'), local('IBMPlexMono-Light'),
       url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6qfjptAgt5VM-kVkqdyU8n3oQIwlBFgsAXHNk.woff2)
         format('woff2');
@@ -283,6 +311,7 @@
     font-family: 'IBM Plex Mono';
     font-style: normal;
     font-weight: 400;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Mono'), local('IBMPlexMono'),
       url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F63fjptAgt5VM-kVkqdyU8n1iIq131nj-otFQ.woff2)
         format('woff2');
@@ -294,6 +323,7 @@
     font-family: 'IBM Plex Mono';
     font-style: normal;
     font-weight: 400;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Mono'), local('IBMPlexMono'),
       url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F63fjptAgt5VM-kVkqdyU8n1isq131nj-otFQ.woff2)
         format('woff2');
@@ -304,6 +334,7 @@
     font-family: 'IBM Plex Mono';
     font-style: normal;
     font-weight: 400;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Mono'), local('IBMPlexMono'),
       url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F63fjptAgt5VM-kVkqdyU8n1iAq131nj-otFQ.woff2)
         format('woff2');
@@ -314,6 +345,7 @@
     font-family: 'IBM Plex Mono';
     font-style: normal;
     font-weight: 400;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Mono'), local('IBMPlexMono'),
       url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F63fjptAgt5VM-kVkqdyU8n1iEq131nj-otFQ.woff2)
         format('woff2');
@@ -325,6 +357,7 @@
     font-family: 'IBM Plex Mono';
     font-style: normal;
     font-weight: 400;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Mono'), local('IBMPlexMono'),
       url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F63fjptAgt5VM-kVkqdyU8n1i8q131nj-o.woff2)
         format('woff2');
@@ -337,6 +370,7 @@
     font-family: 'IBM Plex Mono';
     font-style: normal;
     font-weight: 600;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Mono SemiBold'), local('IBMPlexMono-SemiBold'),
       url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6qfjptAgt5VM-kVkqdyU8n3vAOwl1FgsAXHNlYzg.woff2)
         format('woff2');
@@ -348,6 +382,7 @@
     font-family: 'IBM Plex Mono';
     font-style: normal;
     font-weight: 600;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Mono SemiBold'), local('IBMPlexMono-SemiBold'),
       url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6qfjptAgt5VM-kVkqdyU8n3vAOwlRFgsAXHNlYzg.woff2)
         format('woff2');
@@ -358,6 +393,7 @@
     font-family: 'IBM Plex Mono';
     font-style: normal;
     font-weight: 600;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Mono SemiBold'), local('IBMPlexMono-SemiBold'),
       url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6qfjptAgt5VM-kVkqdyU8n3vAOwl9FgsAXHNlYzg.woff2)
         format('woff2');
@@ -368,6 +404,7 @@
     font-family: 'IBM Plex Mono';
     font-style: normal;
     font-weight: 600;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Mono SemiBold'), local('IBMPlexMono-SemiBold'),
       url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6qfjptAgt5VM-kVkqdyU8n3vAOwl5FgsAXHNlYzg.woff2)
         format('woff2');
@@ -379,6 +416,7 @@
     font-family: 'IBM Plex Mono';
     font-style: normal;
     font-weight: 600;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Mono SemiBold'), local('IBMPlexMono-SemiBold'),
       url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6qfjptAgt5VM-kVkqdyU8n3vAOwlBFgsAXHNk.woff2)
         format('woff2');

--- a/packages/type/scss/font-face/_sans.scss
+++ b/packages/type/scss/font-face/_sans.scss
@@ -5,12 +5,15 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+@import 'settings';
+
 @mixin carbon--font-face-sans {
   // .woff support for IE11
   @font-face {
     font-family: 'IBM Plex Sans';
     font-style: italic;
     font-weight: 300;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Sans Light Italic'), local('IBMPlexSans-LightItalic'),
       url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX7KVElMYYaJe8bpLHnCwDKhdTmvIRcdvfo.woff)
         format('woff');
@@ -19,6 +22,7 @@
     font-family: 'IBM Plex Sans';
     font-style: italic;
     font-weight: 400;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Sans Italic'), local('IBMPlexSans-Italic'),
       url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX-KVElMYYaJe8bpLHnCwDKhdTuF6ZP.woff)
         format('woff');
@@ -27,6 +31,7 @@
     font-family: 'IBM Plex Sans';
     font-style: italic;
     font-weight: 600;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Sans SemiBold Italic'),
       local('IBMPlexSans-SemiBoldItalic'),
       url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX7KVElMYYaJe8bpLHnCwDKhdTmyIJcdvfo.woff)
@@ -36,6 +41,7 @@
     font-family: 'IBM Plex Sans';
     font-style: normal;
     font-weight: 300;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Sans Light'), local('IBMPlexSans-Light'),
       url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjXr8AIFscg.woff)
         format('woff');
@@ -44,6 +50,7 @@
     font-family: 'IBM Plex Sans';
     font-style: normal;
     font-weight: 400;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Sans'), local('IBMPlexSans'),
       url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYXgKVElMYYaJe8bpLHnCwDKhdHeEw.woff)
         format('woff');
@@ -52,6 +59,7 @@
     font-family: 'IBM Plex Sans';
     font-style: normal;
     font-weight: 600;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'),
       url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIFscg.woff)
         format('woff');
@@ -62,6 +70,7 @@
     font-family: 'IBM Plex Sans';
     font-style: italic;
     font-weight: 300;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Sans Light Italic'), local('IBMPlexSans-LightItalic'),
       url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX7KVElMYYaJe8bpLHnCwDKhdTmvIRce_fuJGl18QRY.woff2)
         format('woff2');
@@ -73,6 +82,7 @@
     font-family: 'IBM Plex Sans';
     font-style: italic;
     font-weight: 300;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Sans Light Italic'), local('IBMPlexSans-LightItalic'),
       url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX7KVElMYYaJe8bpLHnCwDKhdTmvIRccvfuJGl18QRY.woff2)
         format('woff2');
@@ -83,6 +93,7 @@
     font-family: 'IBM Plex Sans';
     font-style: italic;
     font-weight: 300;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Sans Light Italic'), local('IBMPlexSans-LightItalic'),
       url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX7KVElMYYaJe8bpLHnCwDKhdTmvIRcdffuJGl18QRY.woff2)
         format('woff2');
@@ -93,6 +104,7 @@
     font-family: 'IBM Plex Sans';
     font-style: italic;
     font-weight: 300;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Sans Light Italic'), local('IBMPlexSans-LightItalic'),
       url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX7KVElMYYaJe8bpLHnCwDKhdTmvIRceffuJGl18QRY.woff2)
         format('woff2');
@@ -103,6 +115,7 @@
     font-family: 'IBM Plex Sans';
     font-style: italic;
     font-weight: 300;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Sans Light Italic'), local('IBMPlexSans-LightItalic'),
       url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX7KVElMYYaJe8bpLHnCwDKhdTmvIRcePfuJGl18QRY.woff2)
         format('woff2');
@@ -114,6 +127,7 @@
     font-family: 'IBM Plex Sans';
     font-style: italic;
     font-weight: 300;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Sans Light Italic'), local('IBMPlexSans-LightItalic'),
       url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX7KVElMYYaJe8bpLHnCwDKhdTmvIRcdvfuJGl18Q.woff2)
         format('woff2');
@@ -126,6 +140,7 @@
     font-family: 'IBM Plex Sans';
     font-style: italic;
     font-weight: 400;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Sans Italic'), local('IBMPlexSans-Italic'),
       url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX-KVElMYYaJe8bpLHnCwDKhdTuGqZJW9XjDlN8.woff2)
         format('woff2');
@@ -137,6 +152,7 @@
     font-family: 'IBM Plex Sans';
     font-style: italic;
     font-weight: 400;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Sans Italic'), local('IBMPlexSans-Italic'),
       url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX-KVElMYYaJe8bpLHnCwDKhdTuE6ZJW9XjDlN8.woff2)
         format('woff2');
@@ -147,6 +163,7 @@
     font-family: 'IBM Plex Sans';
     font-style: italic;
     font-weight: 400;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Sans Italic'), local('IBMPlexSans-Italic'),
       url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX-KVElMYYaJe8bpLHnCwDKhdTuFKZJW9XjDlN8.woff2)
         format('woff2');
@@ -157,6 +174,7 @@
     font-family: 'IBM Plex Sans';
     font-style: italic;
     font-weight: 400;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Sans Italic'), local('IBMPlexSans-Italic'),
       url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX-KVElMYYaJe8bpLHnCwDKhdTuGKZJW9XjDlN8.woff2)
         format('woff2');
@@ -167,6 +185,7 @@
     font-family: 'IBM Plex Sans';
     font-style: italic;
     font-weight: 400;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Sans Italic'), local('IBMPlexSans-Italic'),
       url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX-KVElMYYaJe8bpLHnCwDKhdTuGaZJW9XjDlN8.woff2)
         format('woff2');
@@ -178,6 +197,7 @@
     font-family: 'IBM Plex Sans';
     font-style: italic;
     font-weight: 400;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Sans Italic'), local('IBMPlexSans-Italic'),
       url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX-KVElMYYaJe8bpLHnCwDKhdTuF6ZJW9XjDg.woff2)
         format('woff2');
@@ -190,6 +210,7 @@
     font-family: 'IBM Plex Sans';
     font-style: italic;
     font-weight: 600;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Sans SemiBold Italic'),
       local('IBMPlexSans-SemiBoldItalic'),
       url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX7KVElMYYaJe8bpLHnCwDKhdTmyIJce_fuJGl18QRY.woff2)
@@ -202,6 +223,7 @@
     font-family: 'IBM Plex Sans';
     font-style: italic;
     font-weight: 600;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Sans SemiBold Italic'),
       local('IBMPlexSans-SemiBoldItalic'),
       url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX7KVElMYYaJe8bpLHnCwDKhdTmyIJccvfuJGl18QRY.woff2)
@@ -213,6 +235,7 @@
     font-family: 'IBM Plex Sans';
     font-style: italic;
     font-weight: 600;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Sans SemiBold Italic'),
       local('IBMPlexSans-SemiBoldItalic'),
       url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX7KVElMYYaJe8bpLHnCwDKhdTmyIJcdffuJGl18QRY.woff2)
@@ -224,6 +247,7 @@
     font-family: 'IBM Plex Sans';
     font-style: italic;
     font-weight: 600;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Sans SemiBold Italic'),
       local('IBMPlexSans-SemiBoldItalic'),
       url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX7KVElMYYaJe8bpLHnCwDKhdTmyIJceffuJGl18QRY.woff2)
@@ -235,6 +259,7 @@
     font-family: 'IBM Plex Sans';
     font-style: italic;
     font-weight: 600;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Sans SemiBold Italic'),
       local('IBMPlexSans-SemiBoldItalic'),
       url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX7KVElMYYaJe8bpLHnCwDKhdTmyIJcePfuJGl18QRY.woff2)
@@ -247,6 +272,7 @@
     font-family: 'IBM Plex Sans';
     font-style: italic;
     font-weight: 600;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Sans SemiBold Italic'),
       local('IBMPlexSans-SemiBoldItalic'),
       url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX7KVElMYYaJe8bpLHnCwDKhdTmyIJcdvfuJGl18Q.woff2)
@@ -260,6 +286,7 @@
     font-family: 'IBM Plex Sans';
     font-style: normal;
     font-weight: 300;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Sans Light'), local('IBMPlexSans-Light'),
       url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjXr8AIxsdP3pBmtF8A.woff2)
         format('woff2');
@@ -271,6 +298,7 @@
     font-family: 'IBM Plex Sans';
     font-style: normal;
     font-weight: 300;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Sans Light'), local('IBMPlexSans-Light'),
       url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjXr8AIVsdP3pBmtF8A.woff2)
         format('woff2');
@@ -281,6 +309,7 @@
     font-family: 'IBM Plex Sans';
     font-style: normal;
     font-weight: 300;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Sans Light'), local('IBMPlexSans-Light'),
       url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjXr8AIJsdP3pBmtF8A.woff2)
         format('woff2');
@@ -291,6 +320,7 @@
     font-family: 'IBM Plex Sans';
     font-style: normal;
     font-weight: 300;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Sans Light'), local('IBMPlexSans-Light'),
       url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjXr8AI5sdP3pBmtF8A.woff2)
         format('woff2');
@@ -301,6 +331,7 @@
     font-family: 'IBM Plex Sans';
     font-style: normal;
     font-weight: 300;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Sans Light'), local('IBMPlexSans-Light'),
       url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjXr8AI9sdP3pBmtF8A.woff2)
         format('woff2');
@@ -312,6 +343,7 @@
     font-family: 'IBM Plex Sans';
     font-style: normal;
     font-weight: 300;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Sans Light'), local('IBMPlexSans-Light'),
       url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjXr8AIFsdP3pBms.woff2)
         format('woff2');
@@ -324,6 +356,7 @@
     font-family: 'IBM Plex Sans';
     font-style: normal;
     font-weight: 400;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Sans'), local('IBMPlexSans'),
       url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYXgKVElMYYaJe8bpLHnCwDKhdzeFaxOedfTDw.woff2)
         format('woff2');
@@ -335,6 +368,7 @@
     font-family: 'IBM Plex Sans';
     font-style: normal;
     font-weight: 400;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Sans'), local('IBMPlexSans'),
       url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYXgKVElMYYaJe8bpLHnCwDKhdXeFaxOedfTDw.woff2)
         format('woff2');
@@ -345,6 +379,7 @@
     font-family: 'IBM Plex Sans';
     font-style: normal;
     font-weight: 400;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Sans'), local('IBMPlexSans'),
       url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYXgKVElMYYaJe8bpLHnCwDKhdLeFaxOedfTDw.woff2)
         format('woff2');
@@ -355,6 +390,7 @@
     font-family: 'IBM Plex Sans';
     font-style: normal;
     font-weight: 400;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Sans'), local('IBMPlexSans'),
       url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYXgKVElMYYaJe8bpLHnCwDKhd7eFaxOedfTDw.woff2)
         format('woff2');
@@ -365,6 +401,7 @@
     font-family: 'IBM Plex Sans';
     font-style: normal;
     font-weight: 400;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Sans'), local('IBMPlexSans'),
       url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYXgKVElMYYaJe8bpLHnCwDKhd_eFaxOedfTDw.woff2)
         format('woff2');
@@ -376,6 +413,7 @@
     font-family: 'IBM Plex Sans';
     font-style: normal;
     font-weight: 400;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Sans'), local('IBMPlexSans'),
       url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYXgKVElMYYaJe8bpLHnCwDKhdHeFaxOedc.woff2)
         format('woff2');
@@ -388,6 +426,7 @@
     font-family: 'IBM Plex Sans';
     font-style: normal;
     font-weight: 600;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'),
       url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIxsdP3pBmtF8A.woff2)
         format('woff2');
@@ -399,6 +438,7 @@
     font-family: 'IBM Plex Sans';
     font-style: normal;
     font-weight: 600;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'),
       url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIVsdP3pBmtF8A.woff2)
         format('woff2');
@@ -409,6 +449,7 @@
     font-family: 'IBM Plex Sans';
     font-style: normal;
     font-weight: 600;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'),
       url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIJsdP3pBmtF8A.woff2)
         format('woff2');
@@ -419,6 +460,7 @@
     font-family: 'IBM Plex Sans';
     font-style: normal;
     font-weight: 600;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'),
       url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjQ76AI5sdP3pBmtF8A.woff2)
         format('woff2');
@@ -429,6 +471,7 @@
     font-family: 'IBM Plex Sans';
     font-style: normal;
     font-weight: 600;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'),
       url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjQ76AI9sdP3pBmtF8A.woff2)
         format('woff2');
@@ -440,6 +483,7 @@
     font-family: 'IBM Plex Sans';
     font-style: normal;
     font-weight: 600;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'),
       url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIFsdP3pBms.woff2)
         format('woff2');

--- a/packages/type/scss/font-face/_serif.scss
+++ b/packages/type/scss/font-face/_serif.scss
@@ -5,12 +5,15 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+@import 'settings';
+
 @mixin carbon--font-face-serif {
   // .woff support for IE11
   @font-face {
     font-family: 'IBM Plex Serif';
     font-style: italic;
     font-weight: 300;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Serif Light Italic'), local('IBMPlexSerif-LightItalic'),
       url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizGREVNn1dOx-zrZ2X3pZvkTiUa454xm1npiw.woff)
         format('woff');
@@ -19,6 +22,7 @@
     font-family: 'IBM Plex Serif';
     font-style: italic;
     font-weight: 400;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Serif Italic'), local('IBMPlexSerif-Italic'),
       url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizBREVNn1dOx-zrZ2X3pZvkTiUa6zUTiA.woff)
         format('woff');
@@ -27,6 +31,7 @@
     font-family: 'IBM Plex Serif';
     font-style: italic;
     font-weight: 600;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Serif SemiBold Italic'),
       local('IBMPlexSerif-SemiBoldItalic'),
       url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizGREVNn1dOx-zrZ2X3pZvkTiUa4-o3m1npiw.woff)
@@ -36,6 +41,7 @@
     font-family: 'IBM Plex Serif';
     font-style: normal;
     font-weight: 300;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Serif Light'), local('IBMPlexSerif-Light'),
       url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizAREVNn1dOx-zrZ2X3pZvkTi20-SI0q10.woff)
         format('woff');
@@ -44,6 +50,7 @@
     font-family: 'IBM Plex Serif';
     font-style: normal;
     font-weight: 400;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Serif'), local('IBMPlexSerif'),
       url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizDREVNn1dOx-zrZ2X3pZvkTiUf2zE.woff)
         format('woff');
@@ -52,6 +59,7 @@
     font-family: 'IBM Plex Serif';
     font-style: normal;
     font-weight: 600;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Serif SemiBold'), local('IBMPlexSerif-SemiBold'),
       url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizAREVNn1dOx-zrZ2X3pZvkTi3A_yI0q10.woff)
         format('woff');
@@ -62,6 +70,7 @@
     font-family: 'IBM Plex Serif';
     font-style: italic;
     font-weight: 300;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Serif Light Italic'), local('IBMPlexSerif-LightItalic'),
       url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizGREVNn1dOx-zrZ2X3pZvkTiUa454xm1TpjfGj7oaMBg.woff2)
         format('woff2');
@@ -73,6 +82,7 @@
     font-family: 'IBM Plex Serif';
     font-style: italic;
     font-weight: 300;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Serif Light Italic'), local('IBMPlexSerif-LightItalic'),
       url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizGREVNn1dOx-zrZ2X3pZvkTiUa454xm13pjfGj7oaMBg.woff2)
         format('woff2');
@@ -83,6 +93,7 @@
     font-family: 'IBM Plex Serif';
     font-style: italic;
     font-weight: 300;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Serif Light Italic'), local('IBMPlexSerif-LightItalic'),
       url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizGREVNn1dOx-zrZ2X3pZvkTiUa454xm1bpjfGj7oaMBg.woff2)
         format('woff2');
@@ -93,6 +104,7 @@
     font-family: 'IBM Plex Serif';
     font-style: italic;
     font-weight: 300;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Serif Light Italic'), local('IBMPlexSerif-LightItalic'),
       url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizGREVNn1dOx-zrZ2X3pZvkTiUa454xm1fpjfGj7oaMBg.woff2)
         format('woff2');
@@ -104,6 +116,7 @@
     font-family: 'IBM Plex Serif';
     font-style: italic;
     font-weight: 300;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Serif Light Italic'), local('IBMPlexSerif-LightItalic'),
       url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizGREVNn1dOx-zrZ2X3pZvkTiUa454xm1npjfGj7oY.woff2)
         format('woff2');
@@ -116,6 +129,7 @@
     font-family: 'IBM Plex Serif';
     font-style: italic;
     font-weight: 400;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Serif Italic'), local('IBMPlexSerif-Italic'),
       url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizBREVNn1dOx-zrZ2X3pZvkTiUa6zgTjnTLgNuZ5w.woff2)
         format('woff2');
@@ -127,6 +141,7 @@
     font-family: 'IBM Plex Serif';
     font-style: italic;
     font-weight: 400;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Serif Italic'), local('IBMPlexSerif-Italic'),
       url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizBREVNn1dOx-zrZ2X3pZvkTiUa6zETjnTLgNuZ5w.woff2)
         format('woff2');
@@ -137,6 +152,7 @@
     font-family: 'IBM Plex Serif';
     font-style: italic;
     font-weight: 400;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Serif Italic'), local('IBMPlexSerif-Italic'),
       url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizBREVNn1dOx-zrZ2X3pZvkTiUa6zoTjnTLgNuZ5w.woff2)
         format('woff2');
@@ -147,6 +163,7 @@
     font-family: 'IBM Plex Serif';
     font-style: italic;
     font-weight: 400;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Serif Italic'), local('IBMPlexSerif-Italic'),
       url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizBREVNn1dOx-zrZ2X3pZvkTiUa6zsTjnTLgNuZ5w.woff2)
         format('woff2');
@@ -158,6 +175,7 @@
     font-family: 'IBM Plex Serif';
     font-style: italic;
     font-weight: 400;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Serif Italic'), local('IBMPlexSerif-Italic'),
       url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizBREVNn1dOx-zrZ2X3pZvkTiUa6zUTjnTLgNs.woff2)
         format('woff2');
@@ -170,6 +188,7 @@
     font-family: 'IBM Plex Serif';
     font-style: italic;
     font-weight: 600;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Serif SemiBold Italic'),
       local('IBMPlexSerif-SemiBoldItalic'),
       url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizGREVNn1dOx-zrZ2X3pZvkTiUa4-o3m1TpjfGj7oaMBg.woff2)
@@ -182,6 +201,7 @@
     font-family: 'IBM Plex Serif';
     font-style: italic;
     font-weight: 600;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Serif SemiBold Italic'),
       local('IBMPlexSerif-SemiBoldItalic'),
       url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizGREVNn1dOx-zrZ2X3pZvkTiUa4-o3m13pjfGj7oaMBg.woff2)
@@ -193,6 +213,7 @@
     font-family: 'IBM Plex Serif';
     font-style: italic;
     font-weight: 600;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Serif SemiBold Italic'),
       local('IBMPlexSerif-SemiBoldItalic'),
       url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizGREVNn1dOx-zrZ2X3pZvkTiUa4-o3m1bpjfGj7oaMBg.woff2)
@@ -204,6 +225,7 @@
     font-family: 'IBM Plex Serif';
     font-style: italic;
     font-weight: 600;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Serif SemiBold Italic'),
       local('IBMPlexSerif-SemiBoldItalic'),
       url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizGREVNn1dOx-zrZ2X3pZvkTiUa4-o3m1fpjfGj7oaMBg.woff2)
@@ -216,6 +238,7 @@
     font-family: 'IBM Plex Serif';
     font-style: italic;
     font-weight: 600;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Serif SemiBold Italic'),
       local('IBMPlexSerif-SemiBoldItalic'),
       url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizGREVNn1dOx-zrZ2X3pZvkTiUa4-o3m1npjfGj7oY.woff2)
@@ -229,6 +252,7 @@
     font-family: 'IBM Plex Serif';
     font-style: normal;
     font-weight: 300;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Serif Light'), local('IBMPlexSerif-Light'),
       url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizAREVNn1dOx-zrZ2X3pZvkTi20-SI5q1vjitOh3oc.woff2)
         format('woff2');
@@ -240,6 +264,7 @@
     font-family: 'IBM Plex Serif';
     font-style: normal;
     font-weight: 300;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Serif Light'), local('IBMPlexSerif-Light'),
       url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizAREVNn1dOx-zrZ2X3pZvkTi20-SIwq1vjitOh3oc.woff2)
         format('woff2');
@@ -250,6 +275,7 @@
     font-family: 'IBM Plex Serif';
     font-style: normal;
     font-weight: 300;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Serif Light'), local('IBMPlexSerif-Light'),
       url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizAREVNn1dOx-zrZ2X3pZvkTi20-SI7q1vjitOh3oc.woff2)
         format('woff2');
@@ -260,6 +286,7 @@
     font-family: 'IBM Plex Serif';
     font-style: normal;
     font-weight: 300;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Serif Light'), local('IBMPlexSerif-Light'),
       url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizAREVNn1dOx-zrZ2X3pZvkTi20-SI6q1vjitOh3oc.woff2)
         format('woff2');
@@ -271,6 +298,7 @@
     font-family: 'IBM Plex Serif';
     font-style: normal;
     font-weight: 300;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Serif Light'), local('IBMPlexSerif-Light'),
       url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizAREVNn1dOx-zrZ2X3pZvkTi20-SI0q1vjitOh.woff2)
         format('woff2');
@@ -283,6 +311,7 @@
     font-family: 'IBM Plex Serif';
     font-style: normal;
     font-weight: 400;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Serif'), local('IBMPlexSerif'),
       url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizDREVNn1dOx-zrZ2X3pZvkTiUS2zcZiVbJsNo.woff2)
         format('woff2');
@@ -294,6 +323,7 @@
     font-family: 'IBM Plex Serif';
     font-style: normal;
     font-weight: 400;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Serif'), local('IBMPlexSerif'),
       url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizDREVNn1dOx-zrZ2X3pZvkTiUb2zcZiVbJsNo.woff2)
         format('woff2');
@@ -304,6 +334,7 @@
     font-family: 'IBM Plex Serif';
     font-style: normal;
     font-weight: 400;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Serif'), local('IBMPlexSerif'),
       url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizDREVNn1dOx-zrZ2X3pZvkTiUQ2zcZiVbJsNo.woff2)
         format('woff2');
@@ -314,6 +345,7 @@
     font-family: 'IBM Plex Serif';
     font-style: normal;
     font-weight: 400;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Serif'), local('IBMPlexSerif'),
       url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizDREVNn1dOx-zrZ2X3pZvkTiUR2zcZiVbJsNo.woff2)
         format('woff2');
@@ -325,6 +357,7 @@
     font-family: 'IBM Plex Serif';
     font-style: normal;
     font-weight: 400;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Serif'), local('IBMPlexSerif'),
       url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizDREVNn1dOx-zrZ2X3pZvkTiUf2zcZiVbJ.woff2)
         format('woff2');
@@ -337,6 +370,7 @@
     font-family: 'IBM Plex Serif';
     font-style: normal;
     font-weight: 600;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Serif SemiBold'), local('IBMPlexSerif-SemiBold'),
       url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizAREVNn1dOx-zrZ2X3pZvkTi3A_yI5q1vjitOh3oc.woff2)
         format('woff2');
@@ -348,6 +382,7 @@
     font-family: 'IBM Plex Serif';
     font-style: normal;
     font-weight: 600;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Serif SemiBold'), local('IBMPlexSerif-SemiBold'),
       url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizAREVNn1dOx-zrZ2X3pZvkTi3A_yIwq1vjitOh3oc.woff2)
         format('woff2');
@@ -358,6 +393,7 @@
     font-family: 'IBM Plex Serif';
     font-style: normal;
     font-weight: 600;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Serif SemiBold'), local('IBMPlexSerif-SemiBold'),
       url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizAREVNn1dOx-zrZ2X3pZvkTi3A_yI7q1vjitOh3oc.woff2)
         format('woff2');
@@ -368,6 +404,7 @@
     font-family: 'IBM Plex Serif';
     font-style: normal;
     font-weight: 600;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Serif SemiBold'), local('IBMPlexSerif-SemiBold'),
       url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizAREVNn1dOx-zrZ2X3pZvkTi3A_yI6q1vjitOh3oc.woff2)
         format('woff2');
@@ -379,6 +416,7 @@
     font-family: 'IBM Plex Serif';
     font-style: normal;
     font-weight: 600;
+    font-display: $carbon--font-display;
     src: local('IBM Plex Serif SemiBold'), local('IBMPlexSerif-SemiBold'),
       url(https://fonts.gstatic.com/s/ibmplexserif/v7/jizAREVNn1dOx-zrZ2X3pZvkTi3A_yI0q1vjitOh.woff2)
         format('woff2');

--- a/packages/type/scss/font-face/_settings.scss
+++ b/packages/type/scss/font-face/_settings.scss
@@ -1,0 +1,10 @@
+//
+// Copyright IBM Corp. 2018, 2018
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// Defines how font files are loaded and displayed by the browser.
+// https://css-tricks.com/almanac/properties/f/font-display/
+$carbon--font-display: auto !default;


### PR DESCRIPTION
Closes #476

The default setting here doesn't change any behavior. User's can optionally override the `$carbon--font-display` variable to suit their application's Flash of Unstyled Text (FOUT) tolerance.

Additional, future, settings could include: 

- additional weights
- exclude `local()` src
- special characters

#### Changelog

**New**

- `font-face/_settings.scss`
- `font-display` in font face declarations

