### PR TITLE
docs(icons-*): update icon READMEs

### DIFF
--- a/packages/icons-angular/README.md
+++ b/packages/icons-angular/README.md
@@ -42,6 +42,9 @@ import { Add32Module } from '@carbon/icons-angular/lib/add/32.js';
 export class MyModule {}
 ```
 
+_Note: if you would like to find the import path for an icon, you can reference
+our [icon preview](https://carbon-elements.netlify.com/icons/examples/preview/)_
+
 In your component template:
 
 ```html

--- a/packages/icons-react/README.md
+++ b/packages/icons-react/README.md
@@ -39,6 +39,9 @@ To import using CommonJS, you can do the following:
 const Add24 = require('@carbon/icons-react/lib/Add/24');
 ```
 
+_Note: if you would like to find the import path for an icon, you can reference
+our [icon preview](https://carbon-elements.netlify.com/icons/examples/preview/)_
+
 ## 🙌 Contributing
 
 We're always looking for contributors to help us fix bugs, build new

--- a/packages/icons-vue/README.md
+++ b/packages/icons-vue/README.md
@@ -30,7 +30,8 @@ ways. The first is to install them when you're initializing your Vue
 app. For example:
 
 ```js
-import { CarbonIconsVue, Bee32 } from '@carbon/icons-vue';
+import { CarbonIconsVue } from '@carbon/icons-vue';
+import Bee32 from '@carbon/icons-vue/es/bee/32';
 import Vue from 'vue';
 import App from './App.vue';
 
@@ -45,6 +46,9 @@ new Vue({
 }).$mount('#app');
 ```
 
+_Note: if you would like to find the import path for an icon, you can reference
+our [icon preview](https://carbon-elements.netlify.com/icons/examples/preview/)_
+
 Using `CarbonIconsVue` we can pass in any of the icon components that
 we'd like to use. In our application, we can then use them by doing:
 
@@ -58,7 +62,7 @@ If you would rather not register icons globally, you can also import
 them into individual components.
 
 ```js
-import { Bee32 } from '@carbon/icons-vue';
+import Bee32 from '@carbon/icons-vue/es/bee/32';
 
 export default {
   name: 'MyComponent',


### PR DESCRIPTION
Closes #482 

Update icon library READMEs to reflect current guidance for finding import path.

#### Changelog

**New**

**Changed**

- `icons-*` packages now use correct import paths and reference netlify demo for looking up path

**Removed**
