### PR TITLE
fix(icons): include scss folder in package

### DIFF
--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -10,6 +10,7 @@
   "files": [
     "es",
     "lib",
+    "scss",
     "svg",
     "umd"
   ],


### PR DESCRIPTION
Update `@carbon/icons` to include `scss` folder in `files`.