### PR TITLE
chore(docs): fix typo in color variable migration docs

### DIFF
--- a/docs/migration/10.x-color.md
+++ b/docs/migration/10.x-color.md
@@ -23,7 +23,7 @@ Legend:
 | `brand-01`             | replaced with `interactive-01` |
 | `brand-02`             | replaced with `interactive-02` |
 | `brand-03`             | replaced with `interactive-03` |
-|                        | ✨ `interaction-04`            |
+|                        | ✨ `interactive-04`            |
 | `ui-01`                | No change                      |
 | `ui-02`                | No change                      |
 | `ui-03`                | No change                      |


### PR DESCRIPTION
The migration docs show a new variable `interaction-04`, but it's actually called `interactive-04`. This fixes the typo

#### Changelog

**Changed**

- Replaced incorrect variable name `interaction-04` with `interactive-04` in 10.x-color.md