### PR TITLE
fix(icons-react): data attributes are no longer transformed

### DIFF
--- a/packages/icons-react/src/__tests__/createFromInfo-test.js
+++ b/packages/icons-react/src/__tests__/createFromInfo-test.js
@@ -166,5 +166,37 @@ describe('createFromInfo', () => {
       getContainer().focus();
       expect(document.activeElement === getContainer()).toBe(true);
     });
+
+    it('should not transform data attributes', async () => {
+      const dataTestId = 1;
+      const descriptor = {
+        attrs: {
+          width: 16,
+          height: 16,
+          viewBox: '0 0 16 16',
+        },
+        content: [
+          {
+            elem: 'circle',
+            attrs: {
+              cx: 8,
+              cy: 8,
+              r: 8,
+              'data-test-id': dataTestId,
+            },
+          },
+        ],
+      };
+      const moduleSource = createModuleFromInfo({
+        descriptor,
+        moduleName: 'MockIcon',
+      });
+      const MockIconComponent = await getModuleFromString(moduleSource);
+
+      ReactDOM.render(<MockIconComponent />, mountNode);
+      expect(
+        mountNode.querySelector(`[data-test-id="${dataTestId}"]`)
+      ).toBeDefined();
+    });
   });
 });

--- a/packages/icons-react/src/createFromInfo.js
+++ b/packages/icons-react/src/createFromInfo.js
@@ -24,7 +24,7 @@ const babelOptions = {
   ],
 };
 const prettierOptions = {
-  parser: 'babylon',
+  parser: 'babel',
   printWidth: 80,
   singleQuote: true,
   trailingComma: 'es5',
@@ -65,6 +65,12 @@ export default ${info.moduleName};
 function iconToString(descriptor) {
   const { elem, attrs = {}, content = [] } = descriptor;
   const props = Object.keys(attrs).reduce((acc, key) => {
+    if (key.includes('data-')) {
+      return {
+        ...acc,
+        [key]: attrs[key],
+      };
+    }
     return {
       ...acc,
       [camelCase(key)]: attrs[key],


### PR DESCRIPTION
Closes #498

#### Changelog

**New**

**Changed**

- Update `createFromInfo` to not camel-case `data-` attributes

**Removed**
